### PR TITLE
Implement delivery team PoC agents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+project/outputs/*.json
+__pycache__/

--- a/agents/poc_1_delivery/base.py
+++ b/agents/poc_1_delivery/base.py
@@ -1,0 +1,29 @@
+import json
+from pathlib import Path
+from typing import Dict, Any
+
+
+class BaseAgent:
+    """Simple agent that loads a prompt and produces templated output."""
+
+    def __init__(self, name: str, prompt_path: Path):
+        self.name = name
+        with open(prompt_path) as f:
+            content = f.read()
+        # very naive YAML parsing for `prompt:` key
+        if content.startswith('prompt:'):
+            self.prompt = content.split('\n', 1)[1].lstrip()
+        else:
+            self.prompt = content
+        self.trace = []
+
+    def record(self, step: str, output: Any):
+        self.trace.append({'step': step, 'output': output})
+
+    def save_output(self, path: Path, output: Any):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with open(path, 'w') as f:
+            json.dump(output, f, indent=2)
+
+    def run(self, *args, **kwargs):
+        raise NotImplementedError

--- a/agents/poc_1_delivery/delivery_lead_agent.py
+++ b/agents/poc_1_delivery/delivery_lead_agent.py
@@ -1,0 +1,63 @@
+from pathlib import Path
+from typing import Dict
+
+from .po_planner_agent import POPlannerAgent
+from .po_review_agent import POReviewAgent
+from .dor_refiner_agent import DoRRefinerAgent
+from .dev_agent import DevAgent
+from .test_agent import TestAgent
+from .deploy_agent import DeployAgent
+from .docs_agent import DocsAgent
+from .evaluator_agent import EvaluatorAgent
+
+
+class DeliveryLeadAgent:
+    def __init__(self, use_search: bool = False):
+        self.planner = POPlannerAgent()
+        self.reviewer = POReviewAgent(use_search=use_search)
+        self.evaluator = EvaluatorAgent()
+        self.refiner = DoRRefinerAgent()
+        self.dev = DevAgent()
+        self.test = TestAgent()
+        self.deploy = DeployAgent()
+        self.docs = DocsAgent()
+        self.trace = []
+
+    def run(self, feature_idea: str) -> Dict:
+        output = {}
+
+        stories = self.planner.run(feature_idea)
+        self.trace.extend(self.planner.trace)
+        output['stories'] = stories
+
+        review = self.reviewer.run(stories)
+        self.trace.extend(self.reviewer.trace)
+        output['review'] = review
+
+        eval_result = self.evaluator.run(review)
+        self.trace.extend(self.evaluator.trace)
+        output['evaluation'] = eval_result
+        if eval_result['needs_changes']:
+            return output
+
+        refined = self.refiner.run(stories)
+        self.trace.extend(self.refiner.trace)
+        output['refined'] = refined
+
+        code = self.dev.run(refined)
+        self.trace.extend(self.dev.trace)
+        output['code'] = code
+
+        test_results = self.test.run(code)
+        self.trace.extend(self.test.trace)
+        output['tests'] = test_results
+
+        deploy_plan = self.deploy.run(code)
+        self.trace.extend(self.deploy.trace)
+        output['deploy'] = deploy_plan
+
+        docs = self.docs.run(deploy_plan)
+        self.trace.extend(self.docs.trace)
+        output['docs'] = docs
+
+        return output

--- a/agents/poc_1_delivery/deploy_agent.py
+++ b/agents/poc_1_delivery/deploy_agent.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+from typing import Dict
+from .base import BaseAgent
+
+class DeployAgent(BaseAgent):
+    def __init__(self):
+        super().__init__('Deploy', Path('prompts/deploy.yaml'))
+
+    def run(self, build_artifact: Dict) -> Dict:
+        plan = {
+            'version': '1.0.1',
+            'notes': 'Deployed to staging'
+        }
+        self.record('deploy', plan)
+        return plan

--- a/agents/poc_1_delivery/dev_agent.py
+++ b/agents/poc_1_delivery/dev_agent.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+from typing import Dict
+from .base import BaseAgent
+
+class DevAgent(BaseAgent):
+    def __init__(self):
+        super().__init__('Dev', Path('prompts/dev.yaml'))
+
+    def run(self, stories: Dict) -> Dict:
+        code = "# prototype code\nprint('hello world')"
+        output = {'code': code}
+        self.record('develop', output)
+        return output

--- a/agents/poc_1_delivery/docs_agent.py
+++ b/agents/poc_1_delivery/docs_agent.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+from typing import Dict
+from .base import BaseAgent
+
+class DocsAgent(BaseAgent):
+    def __init__(self):
+        super().__init__('Docs', Path('prompts/docs.yaml'))
+
+    def run(self, deploy_output: Dict) -> Dict:
+        doc = f"## Release {deploy_output['version']}\n{deploy_output['notes']}"
+        output = {'documentation': doc}
+        self.record('docs', output)
+        return output

--- a/agents/poc_1_delivery/dor_refiner_agent.py
+++ b/agents/poc_1_delivery/dor_refiner_agent.py
@@ -1,0 +1,12 @@
+from pathlib import Path
+from typing import Dict
+from .base import BaseAgent
+
+class DoRRefinerAgent(BaseAgent):
+    def __init__(self):
+        super().__init__('DoRRefiner', Path('prompts/dor_refiner.yaml'))
+
+    def run(self, stories: Dict) -> Dict:
+        refined = {'stories': [{**s, 'ready': True} for s in stories.get('stories', [])]}
+        self.record('refine', refined)
+        return refined

--- a/agents/poc_1_delivery/evaluator_agent.py
+++ b/agents/poc_1_delivery/evaluator_agent.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+from typing import Dict
+from .base import BaseAgent
+
+class EvaluatorAgent(BaseAgent):
+    def __init__(self):
+        super().__init__('Evaluator', Path('prompts/evaluator.yaml'))
+
+    def run(self, stage_output: Dict) -> Dict:
+        needs_changes = False
+        if isinstance(stage_output, dict) and 'approved' in stage_output:
+            needs_changes = not stage_output.get('approved', True)
+        output = {'needs_changes': needs_changes}
+        self.record('evaluate', output)
+        return output

--- a/agents/poc_1_delivery/po_planner_agent.py
+++ b/agents/poc_1_delivery/po_planner_agent.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+from typing import List, Dict
+from .base import BaseAgent
+
+class POPlannerAgent(BaseAgent):
+    def __init__(self):
+        super().__init__('POPlanner', Path('prompts/po_planner.yaml'))
+
+    def run(self, feature_idea: str) -> Dict:
+        stories = []
+        for i, idea in enumerate(feature_idea.split('\n')[:3], start=1):
+            stories.append({'id': f'STORY-{i}', 'title': idea.strip(), 'description': idea.strip()})
+        output = {'stories': stories}
+        self.record('plan', output)
+        return output

--- a/agents/poc_1_delivery/po_review_agent.py
+++ b/agents/poc_1_delivery/po_review_agent.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+from typing import Dict
+from .base import BaseAgent
+from tools.web_search_tool import WebSearchTool
+
+class POReviewAgent(BaseAgent):
+    def __init__(self, use_search: bool = False):
+        super().__init__('POReview', Path('prompts/po_review.yaml'))
+        self.use_search = use_search
+        self.search_tool = WebSearchTool() if use_search else None
+
+    def run(self, stories: Dict) -> Dict:
+        comments = 'Looks good.'
+        if self.use_search:
+            search_results = self.search_tool('similar features')
+            comments += f' Ref: {search_results}'
+        output = {'approved': True, 'comments': comments}
+        self.record('review', output)
+        return output

--- a/agents/poc_1_delivery/test_agent.py
+++ b/agents/poc_1_delivery/test_agent.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+from typing import Dict
+from .base import BaseAgent
+from tools.test_tool import RunUnitTestsTool
+
+class TestAgent(BaseAgent):
+    def __init__(self):
+        super().__init__('Test', Path('prompts/test.yaml'))
+        self.tool = RunUnitTestsTool()
+
+    def run(self, dev_output: Dict) -> Dict:
+        results = self.tool(dev_output['code'])
+        self.record('test', results)
+        return results

--- a/data/project_snapshot.json
+++ b/data/project_snapshot.json
@@ -1,0 +1,5 @@
+{
+    "project": "AwesomeApp",
+    "version": "1.0.0",
+    "modules": ["auth", "dashboard", "reports"]
+}

--- a/prompts/deploy.yaml
+++ b/prompts/deploy.yaml
@@ -1,0 +1,2 @@
+prompt: |
+  Produce a deployment plan for the prototype.

--- a/prompts/dev.yaml
+++ b/prompts/dev.yaml
@@ -1,0 +1,2 @@
+prompt: |
+  Provide a code snippet prototype for the stories.

--- a/prompts/docs.yaml
+++ b/prompts/docs.yaml
@@ -1,0 +1,2 @@
+prompt: |
+  Write documentation based on the deployment plan.

--- a/prompts/dor_refiner.yaml
+++ b/prompts/dor_refiner.yaml
@@ -1,0 +1,2 @@
+prompt: |
+  Refine the stories to meet the definition of ready.

--- a/prompts/evaluator.yaml
+++ b/prompts/evaluator.yaml
@@ -1,0 +1,2 @@
+prompt: |
+  Evaluate the output and state if changes are needed.

--- a/prompts/po_planner.yaml
+++ b/prompts/po_planner.yaml
@@ -1,0 +1,2 @@
+prompt: |
+  Break the following feature idea into at most 3 user stories. Return as a list.

--- a/prompts/po_review.yaml
+++ b/prompts/po_review.yaml
@@ -1,0 +1,2 @@
+prompt: |
+  Review the stories for alignment with product vision. Respond with approved: true/false and comments.

--- a/prompts/test.yaml
+++ b/prompts/test.yaml
@@ -1,0 +1,2 @@
+prompt: |
+  Describe basic unit tests for the code snippet.

--- a/resources/delivery_standards.md
+++ b/resources/delivery_standards.md
@@ -1,0 +1,5 @@
+# Delivery Standards
+
+- Features should align with product vision.
+- Stories must be clear, concise, and testable.
+- Follow DoR and DoD guidelines.

--- a/scripts/deliver_feature.py
+++ b/scripts/deliver_feature.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+"""CLI entry for running the delivery workflow."""
+import argparse
+import json
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+from workflows.delivery_orchestration import run_delivery_flow
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Run delivery agents")
+    parser.add_argument("feature", help="Feature idea text")
+    parser.add_argument("--use-search", action="store_true", help="Enable web search in review")
+    parser.add_argument("--out", default="project/outputs", help="Output directory")
+    args = parser.parse_args()
+
+    results, trace = run_delivery_flow(args.feature, use_search=args.use_search)
+
+    out_dir = Path(args.out)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    with open(out_dir / "results.json", "w") as f:
+        json.dump(results, f, indent=2)
+    with open(out_dir / "trace.json", "w") as f:
+        json.dump(trace, f, indent=2)
+    print(json.dumps(results, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/test_tool.py
+++ b/tools/test_tool.py
@@ -1,0 +1,7 @@
+class RunUnitTestsTool:
+    """Simulate running unit tests."""
+    name = "run_unit_tests"
+
+    def __call__(self, code: str):
+        # pretend to run tests
+        return {"success": True, "details": "All unit tests passed"}

--- a/tools/web_search_tool.py
+++ b/tools/web_search_tool.py
@@ -1,0 +1,6 @@
+class WebSearchTool:
+    """Mock web search returning static results."""
+    name = "web_search"
+
+    def __call__(self, query: str):
+        return f"Results for '{query}': example best practices."

--- a/workflows/delivery_orchestration.py
+++ b/workflows/delivery_orchestration.py
@@ -1,0 +1,7 @@
+from agents.poc_1_delivery.delivery_lead_agent import DeliveryLeadAgent
+
+
+def run_delivery_flow(feature: str, use_search: bool = False):
+    lead = DeliveryLeadAgent(use_search=use_search)
+    results = lead.run(feature)
+    return results, lead.trace


### PR DESCRIPTION
## Summary
- add initial delivery team agents with simple run logic
- create orchestration workflow and CLI entry
- include simple test and web search tools
- add resources, prompts and mock data

## Testing
- `python scripts/deliver_feature.py "Add dark mode support" --out project/outputs/test`

------
https://chatgpt.com/codex/tasks/task_e_685c679404d4832687c6f25e5fc23ce7