### PR TITLE
Add SDK-based delivery agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,4 +14,4 @@ https://coachingthemachine.substack.com/
 - Showcase the OpenAI Agent SDK's capabilities
 - Use model-agnostic agent design (OpenAI, Gemini, etc.)
 - Demonstrate workflows with guardrails, tool use, tracing, visualization
-- Encourage collaboration and real-world application of agentic systems
+- Encourage collaboration and real-world application of agentic systems\n### Running PoC 1\nExecute `scripts/deliver_feature.py` and follow the prompts to run the delivery agents.

--- a/agents/poc_1_delivery/__init__.py
+++ b/agents/poc_1_delivery/__init__.py
@@ -1,0 +1,1 @@
+from .delivery_lead_agent import DeliveryLeadAgent

--- a/agents/poc_1_delivery/delivery_lead_agent.py
+++ b/agents/poc_1_delivery/delivery_lead_agent.py
@@ -1,18 +1,22 @@
-from pathlib import Path
 from typing import Dict
 
-from .po_planner_agent import POPlannerAgent
-from .po_review_agent import POReviewAgent
-from .dor_refiner_agent import DoRRefinerAgent
-from .dev_agent import DevAgent
-from .test_agent import TestAgent
-from .deploy_agent import DeployAgent
-from .docs_agent import DocsAgent
-from .evaluator_agent import EvaluatorAgent
+from openai_agents.tracing import Trace, traceable
+
+from .po_planner_agent import POPlannerAgent, PlanningOutput
+from .po_review_agent import POReviewAgent, ReviewOutput
+from .dor_refiner_agent import DoRRefinerAgent, RefinedStories
+from .dev_agent import DevAgent, DevOutput
+from .test_agent import TestAgent, TestOutput
+from .deploy_agent import DeployAgent, DeployOutput
+from .docs_agent import DocsAgent, DocsOutput
+from .evaluator_agent import EvaluatorAgent, EvaluationOutput
 
 
 class DeliveryLeadAgent:
+    """Orchestrates the delivery workflow across all sub agents."""
+
     def __init__(self, use_search: bool = False):
+        self.trace = Trace("DeliveryLead")
         self.planner = POPlannerAgent()
         self.reviewer = POReviewAgent(use_search=use_search)
         self.evaluator = EvaluatorAgent()
@@ -21,43 +25,43 @@ class DeliveryLeadAgent:
         self.test = TestAgent()
         self.deploy = DeployAgent()
         self.docs = DocsAgent()
-        self.trace = []
 
+    @traceable
     def run(self, feature_idea: str) -> Dict:
-        output = {}
+        output: Dict[str, object] = {}
 
-        stories = self.planner.run(feature_idea)
-        self.trace.extend(self.planner.trace)
-        output['stories'] = stories
+        stories: PlanningOutput = self.planner.run(feature_idea)
+        self.trace.merge(self.planner.trace)
+        output["stories"] = stories.model_dump()
 
-        review = self.reviewer.run(stories)
-        self.trace.extend(self.reviewer.trace)
-        output['review'] = review
+        review: ReviewOutput = self.reviewer.run(stories.model_dump())
+        self.trace.merge(self.reviewer.trace)
+        output["review"] = review.model_dump()
 
-        eval_result = self.evaluator.run(review)
-        self.trace.extend(self.evaluator.trace)
-        output['evaluation'] = eval_result
-        if eval_result['needs_changes']:
+        evaluation: EvaluationOutput = self.evaluator.run(review)
+        self.trace.merge(self.evaluator.trace)
+        output["evaluation"] = evaluation.model_dump()
+        if evaluation.needs_changes:
             return output
 
-        refined = self.refiner.run(stories)
-        self.trace.extend(self.refiner.trace)
-        output['refined'] = refined
+        refined: RefinedStories = self.refiner.run(stories)
+        self.trace.merge(self.refiner.trace)
+        output["refined"] = refined.model_dump()
 
-        code = self.dev.run(refined)
-        self.trace.extend(self.dev.trace)
-        output['code'] = code
+        code: DevOutput = self.dev.run(refined)
+        self.trace.merge(self.dev.trace)
+        output["code"] = code.model_dump()
 
-        test_results = self.test.run(code)
-        self.trace.extend(self.test.trace)
-        output['tests'] = test_results
+        tests: TestOutput = self.test.run(code)
+        self.trace.merge(self.test.trace)
+        output["tests"] = tests.model_dump()
 
-        deploy_plan = self.deploy.run(code)
-        self.trace.extend(self.deploy.trace)
-        output['deploy'] = deploy_plan
+        deploy_plan: DeployOutput = self.deploy.run(tests)
+        self.trace.merge(self.deploy.trace)
+        output["deploy"] = deploy_plan.model_dump()
 
-        docs = self.docs.run(deploy_plan)
-        self.trace.extend(self.docs.trace)
-        output['docs'] = docs
+        docs: DocsOutput = self.docs.run(deploy_plan)
+        self.trace.merge(self.docs.trace)
+        output["docs"] = docs.model_dump()
 
         return output

--- a/agents/poc_1_delivery/dev_agent.py
+++ b/agents/poc_1_delivery/dev_agent.py
@@ -1,13 +1,33 @@
 from pathlib import Path
-from typing import Dict
+
+import openai
+from pydantic import BaseModel
+
+from openai_agents.tracing import traceable
+
 from .base import BaseAgent
+from .dor_refiner_agent import RefinedStories
+
+
+class DevOutput(BaseModel):
+    code: str
+
 
 class DevAgent(BaseAgent):
     def __init__(self):
-        super().__init__('Dev', Path('prompts/dev.yaml'))
+        super().__init__("Dev", Path("prompts/dev.yaml"))
 
-    def run(self, stories: Dict) -> Dict:
-        code = "# prototype code\nprint('hello world')"
-        output = {'code': code}
-        self.record('develop', output)
+    @traceable
+    def run(self, stories: RefinedStories) -> DevOutput:
+        """Generate prototype code for the refined stories."""
+        response = openai.chat.completions.create(
+            model="gpt-3.5-turbo",
+            messages=[
+                {"role": "system", "content": self.instructions},
+                {"role": "user", "content": stories.model_dump_json()},
+            ],
+        )
+        code = response.choices[0].message.content
+        output = DevOutput(code=code)
+        self.record("develop", output.model_dump())
         return output

--- a/agents/poc_1_delivery/docs_agent.py
+++ b/agents/poc_1_delivery/docs_agent.py
@@ -1,13 +1,33 @@
 from pathlib import Path
-from typing import Dict
+
+import openai
+from pydantic import BaseModel
+
+from openai_agents.tracing import traceable
+
 from .base import BaseAgent
+from .deploy_agent import DeployOutput
+
+
+class DocsOutput(BaseModel):
+    documentation: str
+
 
 class DocsAgent(BaseAgent):
     def __init__(self):
-        super().__init__('Docs', Path('prompts/docs.yaml'))
+        super().__init__("Docs", Path("prompts/docs.yaml"))
 
-    def run(self, deploy_output: Dict) -> Dict:
-        doc = f"## Release {deploy_output['version']}\n{deploy_output['notes']}"
-        output = {'documentation': doc}
-        self.record('docs', output)
+    @traceable
+    def run(self, deploy_output: DeployOutput) -> DocsOutput:
+        """Generate documentation for the deployment."""
+        response = openai.chat.completions.create(
+            model="gpt-3.5-turbo",
+            messages=[
+                {"role": "system", "content": self.instructions},
+                {"role": "user", "content": deploy_output.model_dump_json()},
+            ],
+        )
+        doc = response.choices[0].message.content
+        output = DocsOutput(documentation=doc)
+        self.record("docs", output.model_dump())
         return output

--- a/agents/poc_1_delivery/dor_refiner_agent.py
+++ b/agents/poc_1_delivery/dor_refiner_agent.py
@@ -1,12 +1,30 @@
 from pathlib import Path
-from typing import Dict
+from typing import List
+
+from pydantic import BaseModel
+
+from openai_agents.tracing import traceable
+
 from .base import BaseAgent
+from .po_planner_agent import Story, PlanningOutput
+from tools.validate_dor import ValidateDoR
+
+
+class RefinedStories(BaseModel):
+    stories: List[Story]
+
 
 class DoRRefinerAgent(BaseAgent):
     def __init__(self):
-        super().__init__('DoRRefiner', Path('prompts/dor_refiner.yaml'))
+        super().__init__("DoRRefiner", Path("prompts/dor_refiner.yaml"))
+        self.validator = ValidateDoR()
 
-    def run(self, stories: Dict) -> Dict:
-        refined = {'stories': [{**s, 'ready': True} for s in stories.get('stories', [])]}
-        self.record('refine', refined)
-        return refined
+    @traceable
+    def run(self, stories: PlanningOutput) -> RefinedStories:
+        refined = []
+        for s in stories.stories:
+            ready = self.validator(s.model_dump())
+            refined.append(s.model_copy(update={"ready": ready}))
+        output = RefinedStories(stories=refined)
+        self.record("refine", output.model_dump())
+        return output

--- a/agents/poc_1_delivery/evaluator_agent.py
+++ b/agents/poc_1_delivery/evaluator_agent.py
@@ -1,15 +1,32 @@
 from pathlib import Path
-from typing import Dict
+
+import openai
+from pydantic import BaseModel
+
+from openai_agents.tracing import traceable
+
 from .base import BaseAgent
+
+
+class EvaluationOutput(BaseModel):
+    needs_changes: bool
+
 
 class EvaluatorAgent(BaseAgent):
     def __init__(self):
-        super().__init__('Evaluator', Path('prompts/evaluator.yaml'))
+        super().__init__("Evaluator", Path("prompts/evaluator.yaml"))
 
-    def run(self, stage_output: Dict) -> Dict:
-        needs_changes = False
-        if isinstance(stage_output, dict) and 'approved' in stage_output:
-            needs_changes = not stage_output.get('approved', True)
-        output = {'needs_changes': needs_changes}
-        self.record('evaluate', output)
+    @traceable
+    def run(self, stage_output: BaseModel) -> EvaluationOutput:
+        """Evaluate an intermediate stage and flag if changes are needed."""
+        response = openai.chat.completions.create(
+            model="gpt-3.5-turbo",
+            messages=[
+                {"role": "system", "content": self.instructions},
+                {"role": "user", "content": stage_output.model_dump_json()},
+            ],
+        )
+        content = response.choices[0].message.content.lower()
+        output = EvaluationOutput(needs_changes="change" in content)
+        self.record("evaluate", output.model_dump())
         return output

--- a/agents/poc_1_delivery/po_planner_agent.py
+++ b/agents/poc_1_delivery/po_planner_agent.py
@@ -1,15 +1,41 @@
 from pathlib import Path
-from typing import List, Dict
+from typing import Dict, List
+
+import openai
+from pydantic import BaseModel
+
 from .base import BaseAgent
+from openai_agents.tracing import traceable
+
+
+class Story(BaseModel):
+    id: str
+    title: str
+    description: str
+    ready: bool = False
+
+
+class PlanningOutput(BaseModel):
+    stories: List[Story]
+
 
 class POPlannerAgent(BaseAgent):
     def __init__(self):
-        super().__init__('POPlanner', Path('prompts/po_planner.yaml'))
+        super().__init__("POPlanner", Path("prompts/po_planner.yaml"))
 
-    def run(self, feature_idea: str) -> Dict:
-        stories = []
-        for i, idea in enumerate(feature_idea.split('\n')[:3], start=1):
-            stories.append({'id': f'STORY-{i}', 'title': idea.strip(), 'description': idea.strip()})
-        output = {'stories': stories}
-        self.record('plan', output)
+    @traceable
+    def run(self, feature_idea: str) -> PlanningOutput:
+        """Generate user stories for the feature idea using an LLM call."""
+        response = openai.chat.completions.create(
+            model="gpt-3.5-turbo",
+            messages=[{"role": "system", "content": self.instructions}, {"role": "user", "content": feature_idea}],
+        )
+        ideas = response.choices[0].message.content.split("\n")
+        stories = [
+            Story(id=f"STORY-{i+1}", title=line.strip(), description=line.strip())
+            for i, line in enumerate(ideas[:3])
+            if line.strip()
+        ]
+        output = PlanningOutput(stories=stories)
+        self.record("plan", output.model_dump())
         return output

--- a/agents/poc_1_delivery/po_review_agent.py
+++ b/agents/poc_1_delivery/po_review_agent.py
@@ -1,19 +1,55 @@
 from pathlib import Path
 from typing import Dict
+
+import openai
+from pydantic import BaseModel
+
+from openai_agents.tracing import traceable
+from openai_agents.tools import OpenAITool
+
 from .base import BaseAgent
 from tools.web_search_tool import WebSearchTool
 
+
+class WebSearch(OpenAITool):
+    """OpenAI tool wrapper around the local WebSearchTool."""
+
+    def __init__(self):
+        super().__init__(name="web_search")
+        self.tool = WebSearchTool()
+
+    def run(self, query: str) -> str:  # noqa: D401
+        return self.tool(query)
+
+
+class ReviewOutput(BaseModel):
+    approved: bool
+    comments: str
+
+
 class POReviewAgent(BaseAgent):
     def __init__(self, use_search: bool = False):
-        super().__init__('POReview', Path('prompts/po_review.yaml'))
+        super().__init__("POReview", Path("prompts/po_review.yaml"))
         self.use_search = use_search
-        self.search_tool = WebSearchTool() if use_search else None
+        self.search_tool = WebSearch() if use_search else None
 
-    def run(self, stories: Dict) -> Dict:
-        comments = 'Looks good.'
-        if self.use_search:
-            search_results = self.search_tool('similar features')
-            comments += f' Ref: {search_results}'
-        output = {'approved': True, 'comments': comments}
-        self.record('review', output)
+    @traceable
+    def run(self, stories: Dict) -> ReviewOutput:
+        """Review stories for alignment, optionally using web search."""
+        context = stories
+        search_ref = ""
+        if self.search_tool:
+            search_ref = self.search_tool.run("similar features")
+        response = openai.chat.completions.create(
+            model="gpt-3.5-turbo",
+            messages=[
+                {"role": "system", "content": self.instructions},
+                {"role": "user", "content": str(context)},
+                {"role": "system", "content": search_ref},
+            ],
+        )
+        content = response.choices[0].message.content
+        approved = "approved" in content.lower()
+        output = ReviewOutput(approved=approved, comments=content)
+        self.record("review", output.model_dump())
         return output

--- a/agents/poc_1_delivery/test_agent.py
+++ b/agents/poc_1_delivery/test_agent.py
@@ -1,14 +1,36 @@
 from pathlib import Path
-from typing import Dict
+
+import openai
+from pydantic import BaseModel
+
+from openai_agents.tracing import traceable
+
 from .base import BaseAgent
+from .dev_agent import DevOutput
 from tools.test_tool import RunUnitTestsTool
+
+
+class TestOutput(BaseModel):
+    success: bool
+    details: str
+
 
 class TestAgent(BaseAgent):
     def __init__(self):
-        super().__init__('Test', Path('prompts/test.yaml'))
-        self.tool = RunUnitTestsTool()
+        super().__init__("Test", Path("prompts/test.yaml"))
+        self.runner = RunUnitTestsTool()
 
-    def run(self, dev_output: Dict) -> Dict:
-        results = self.tool(dev_output['code'])
-        self.record('test', results)
-        return results
+    @traceable
+    def run(self, dev_output: DevOutput) -> TestOutput:
+        """Run unit tests and summarize the results."""
+        results = self.runner(dev_output.code)
+        summary = openai.chat.completions.create(
+            model="gpt-3.5-turbo",
+            messages=[
+                {"role": "system", "content": self.instructions},
+                {"role": "user", "content": str(results)},
+            ],
+        ).choices[0].message.content
+        output = TestOutput(success=results["success"], details=summary)
+        self.record("test", output.model_dump())
+        return output

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+openai-agents-python
+openai
+pydantic

--- a/scripts/deliver_feature.py
+++ b/scripts/deliver_feature.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-"""CLI entry for running the delivery workflow."""
+"""CLI entry for running the SDK-based delivery workflow."""
 import argparse
 import json
 from pathlib import Path
@@ -11,20 +11,32 @@ from workflows.delivery_orchestration import run_delivery_flow
 
 def main():
     parser = argparse.ArgumentParser(description="Run delivery agents")
-    parser.add_argument("feature", help="Feature idea text")
+    parser.add_argument("feature", nargs="?", help="Feature idea text")
     parser.add_argument("--use-search", action="store_true", help="Enable web search in review")
     parser.add_argument("--out", default="project/outputs", help="Output directory")
     args = parser.parse_args()
 
-    results, trace = run_delivery_flow(args.feature, use_search=args.use_search)
+    feature = args.feature or input("Enter feature idea: ")
+    results, trace = run_delivery_flow(feature, use_search=args.use_search)
 
     out_dir = Path(args.out)
     out_dir.mkdir(parents=True, exist_ok=True)
     with open(out_dir / "results.json", "w") as f:
         json.dump(results, f, indent=2)
-    with open(out_dir / "trace.json", "w") as f:
-        json.dump(trace, f, indent=2)
+    trace_path = out_dir / "trace.json"
+    with open(trace_path, "w") as f:
+        json.dump(trace.serialize(), f, indent=2)
+
+    # visualize if available
+    try:
+        from openai_agents.visualization import visualize_trace
+
+        visualize_trace(trace, out_dir / "trace_graph.html")
+    except Exception:
+        pass
+
     print(json.dumps(results, indent=2))
+    print(f"Trace saved to {trace_path} with id: {trace.id}")
 
 
 if __name__ == "__main__":

--- a/tools/validate_dor.py
+++ b/tools/validate_dor.py
@@ -1,0 +1,7 @@
+class ValidateDoR:
+    """Custom tool to check if a story meets Definition of Ready (DoR)."""
+    name = "validate_DoR"
+
+    def __call__(self, story: dict) -> bool:
+        required_fields = ["id", "title", "description"]
+        return all(story.get(f) for f in required_fields)

--- a/visualization/README.md
+++ b/visualization/README.md
@@ -1,0 +1,1 @@
+This folder stores agent trace visualizations.

--- a/workflows/delivery_orchestration.py
+++ b/workflows/delivery_orchestration.py
@@ -2,6 +2,7 @@ from agents.poc_1_delivery.delivery_lead_agent import DeliveryLeadAgent
 
 
 def run_delivery_flow(feature: str, use_search: bool = False):
+    """Execute the full delivery workflow and return results and trace."""
     lead = DeliveryLeadAgent(use_search=use_search)
     results = lead.run(feature)
     return results, lead.trace


### PR DESCRIPTION
## Summary
- implement delivery agents using OpenAI Agents SDK patterns
- wrap story planning, review, refinement, dev, test, deploy, docs, and eval in traceable sub-agents
- orchestrate flow via `DeliveryLeadAgent`
- add CLI runner with trace output and visualization hook
- include placeholder visualization directory and requirements

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'openai_agents')*

------
https://chatgpt.com/codex/tasks/task_e_685c6a78d6388326ab7148a9aa3bf678