### PR TITLE
Refactor user story agents to use SDK-driven LLM calls

### DIFF
--- a/agents/poc_1_delivery/user_story_agents/acceptance_agent.py
+++ b/agents/poc_1_delivery/user_story_agents/acceptance_agent.py
@@ -1,7 +1,6 @@
 from pathlib import Path
 from pydantic import BaseModel
 from openai_agents import Agent
-from openai_agents.tools import tool
 
 
 class AcceptanceCriteria(BaseModel):
@@ -14,22 +13,6 @@ class AcceptanceCriteriaAgent(Agent):
         super().__init__(
             name="AcceptanceCriteria",
             instructions=instructions,
-            tools=[self.generate_acceptance],
+            output_type=AcceptanceCriteria,
             handoffs=[next_agent] if next_agent else [],
         )
-
-    @tool
-    def generate_acceptance(self, story: str) -> AcceptanceCriteria:
-        import openai
-
-        resp = openai.chat.completions.create(
-            model="gpt-3.5-turbo",
-            messages=[
-                {"role": "system", "content": self.instructions},
-                {"role": "user", "content": story},
-            ],
-        )
-        content = resp.choices[0].message.content
-        return AcceptanceCriteria(gherkin=content)
-
-    tools = [generate_acceptance]

--- a/agents/poc_1_delivery/user_story_agents/functionality_agent.py
+++ b/agents/poc_1_delivery/user_story_agents/functionality_agent.py
@@ -1,7 +1,6 @@
 from pathlib import Path
 from pydantic import BaseModel
 from openai_agents import Agent
-from openai_agents.tools import tool
 
 
 class FunctionalitySpec(BaseModel):
@@ -14,22 +13,6 @@ class FunctionalityAgent(Agent):
         super().__init__(
             name="Functionality",
             instructions=instructions,
-            tools=[self.generate_functionality],
+            output_type=FunctionalitySpec,
             handoffs=[next_agent] if next_agent else [],
         )
-
-    @tool
-    def generate_functionality(self, feature: str) -> FunctionalitySpec:
-        import openai
-
-        resp = openai.chat.completions.create(
-            model="gpt-3.5-turbo",
-            messages=[
-                {"role": "system", "content": self.instructions},
-                {"role": "user", "content": feature},
-            ],
-        )
-        content = resp.choices[0].message.content
-        return FunctionalitySpec(functions=content)
-
-    tools = [generate_functionality]

--- a/agents/poc_1_delivery/user_story_agents/integration_check_agent.py
+++ b/agents/poc_1_delivery/user_story_agents/integration_check_agent.py
@@ -1,7 +1,6 @@
 from pathlib import Path
 from pydantic import BaseModel
 from openai_agents import Agent
-from openai_agents.tools import tool
 
 
 class IntegrationCheck(BaseModel):
@@ -14,21 +13,6 @@ class IntegrationCheckAgent(Agent):
         super().__init__(
             name="IntegrationCheck",
             instructions=instructions,
-            tools=[self.check_integration],
+            output_type=IntegrationCheck,
             handoffs=[next_agent] if next_agent else [],
         )
-
-    @tool
-    def check_integration(self, feature: str) -> IntegrationCheck:
-        import openai
-
-        resp = openai.chat.completions.create(
-            model="gpt-3.5-turbo",
-            messages=[
-                {"role": "system", "content": self.instructions},
-                {"role": "user", "content": feature},
-            ],
-        )
-        return IntegrationCheck(notes=resp.choices[0].message.content)
-
-    tools = [check_integration]

--- a/agents/poc_1_delivery/user_story_agents/tech_spec_agent.py
+++ b/agents/poc_1_delivery/user_story_agents/tech_spec_agent.py
@@ -1,7 +1,6 @@
 from pathlib import Path
 from pydantic import BaseModel
 from openai_agents import Agent
-from openai_agents.tools import tool
 
 
 class TechSpec(BaseModel):
@@ -14,22 +13,6 @@ class TechSpecAgent(Agent):
         super().__init__(
             name="TechSpec",
             instructions=instructions,
-            tools=[self.generate_tech_spec],
+            output_type=TechSpec,
             handoffs=[next_agent] if next_agent else [],
         )
-
-    @tool
-    def generate_tech_spec(self, feature: str) -> TechSpec:
-        import openai
-
-        resp = openai.chat.completions.create(
-            model="gpt-3.5-turbo",
-            messages=[
-                {"role": "system", "content": self.instructions},
-                {"role": "user", "content": feature},
-            ],
-        )
-        content = resp.choices[0].message.content
-        return TechSpec(modules=content)
-
-    tools = [generate_tech_spec]

--- a/agents/poc_1_delivery/user_story_agents/ux_spec_agent.py
+++ b/agents/poc_1_delivery/user_story_agents/ux_spec_agent.py
@@ -1,7 +1,6 @@
 from pathlib import Path
 from pydantic import BaseModel
 from openai_agents import Agent
-from openai_agents.tools import tool
 
 
 class UXSpec(BaseModel):
@@ -15,24 +14,6 @@ class UXSpecAgent(Agent):
         super().__init__(
             name="UXSpec",
             instructions=instructions,
-            tools=[self.generate_ux_spec],
+            output_type=UXSpec,
             handoffs=[next_agent] if next_agent else [],
         )
-
-    @tool
-    def generate_ux_spec(self, feature: str) -> UXSpec:
-        import openai
-
-        resp = openai.chat.completions.create(
-            model="gpt-3.5-turbo",
-            messages=[
-                {"role": "system", "content": self.instructions},
-                {"role": "user", "content": feature},
-            ],
-        )
-        content = resp.choices[0].message.content
-        personas = content
-        journey = content
-        return UXSpec(personas=personas, journey=journey)
-
-    tools = [generate_ux_spec]


### PR DESCRIPTION
## Summary
- update User Story agents to rely on `output_type`
- remove direct `openai` usage inside UXSpec, Functionality, TechSpec, AcceptanceCriteria and IntegrationCheck agents

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685caf4d8c588326acb1dcdd38c56ed1