### PR TITLE
Add traceable decorators to tools

### DIFF
--- a/tools/estimate_story.py
+++ b/tools/estimate_story.py
@@ -1,5 +1,7 @@
+from openai_agents import traceable
 from openai_agents.tools import tool
 
+@traceable
 @tool
 def story_estimate(story: dict) -> int:
     """Return a fixed story point estimate."""

--- a/tools/impact_assess.py
+++ b/tools/impact_assess.py
@@ -1,5 +1,7 @@
+from openai_agents import traceable
 from openai_agents.tools import tool
 
+@traceable
 @tool
 def impact_assessment(story: dict) -> str:
     """Simple tool to assess impact on existing systems."""

--- a/tools/validate_dor.py
+++ b/tools/validate_dor.py
@@ -1,5 +1,7 @@
+from openai_agents import traceable
 from openai_agents.tools import tool
 
+@traceable
 @tool
 def validate_dor(story: dict) -> bool:
     """Check if a story meets Definition of Ready (DoR)."""


### PR DESCRIPTION
## Summary
- import `traceable` from `openai_agents`
- decorate `story_estimate`, `impact_assessment`, and `validate_dor` with `@traceable`

## Testing
- `pip install -r requirements.txt` *(fails: CONNECT tunnel failed)*
- `python scripts/generate_user_stories.py "example feature"` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_685cb249593c8326b1429812f7d83bdf