### PR TITLE
Add progress printer to user story manager

### DIFF
--- a/agents/poc_1_delivery/user_story_agents/printer.py
+++ b/agents/poc_1_delivery/user_story_agents/printer.py
@@ -1,0 +1,43 @@
+from typing import Any
+
+from rich.console import Console, Group
+from rich.live import Live
+from rich.spinner import Spinner
+
+
+class Printer:
+    """Simple wrapper to stream status updates for the user story manager."""
+
+    def __init__(self, console: Console) -> None:
+        self.live = Live(console=console)
+        self.items: dict[str, tuple[str, bool]] = {}
+        self.hide_done_ids: set[str] = set()
+        self.live.start()
+
+    def end(self) -> None:
+        self.live.stop()
+
+    def hide_done_checkmark(self, item_id: str) -> None:
+        self.hide_done_ids.add(item_id)
+
+    def update_item(
+        self, item_id: str, content: str, is_done: bool = False, hide_checkmark: bool = False
+    ) -> None:
+        self.items[item_id] = (content, is_done)
+        if hide_checkmark:
+            self.hide_done_ids.add(item_id)
+        self.flush()
+
+    def mark_item_done(self, item_id: str) -> None:
+        self.items[item_id] = (self.items[item_id][0], True)
+        self.flush()
+
+    def flush(self) -> None:
+        renderables: list[Any] = []
+        for item_id, (content, is_done) in self.items.items():
+            if is_done:
+                prefix = "✅ " if item_id not in self.hide_done_ids else ""
+                renderables.append(prefix + content)
+            else:
+                renderables.append(Spinner("dots", text=content))
+        self.live.update(Group(*renderables))

--- a/agents/poc_1_delivery/user_story_agents/user_story_lead_agent.py
+++ b/agents/poc_1_delivery/user_story_agents/user_story_lead_agent.py
@@ -2,7 +2,10 @@ from __future__ import annotations
 
 from pydantic import BaseModel
 
-from openai_agents import Runner, gen_trace_id, trace
+from openai_agents import Runner, custom_span, gen_trace_id, trace
+from rich.console import Console
+
+from .printer import Printer
 
 from .tech_context_agent import TechContextAgent, TechContext
 from .ux_spec_agent import UXSpecAgent, UXSpec
@@ -33,6 +36,8 @@ class UserStoryLeadAgent:
     """Manager that orchestrates the user story generation flow."""
 
     def __init__(self) -> None:
+        self.console = Console()
+        self.printer = Printer(self.console)
         self.context_agent = TechContextAgent()
         self.ux_agent = UXSpecAgent()
         self.func_agent = FunctionalityAgent()
@@ -47,32 +52,68 @@ class UserStoryLeadAgent:
         """Run the full user story workflow for the provided feature."""
         trace_id = gen_trace_id()
         with trace("User story trace", trace_id=trace_id):
-            context_res = await Runner.run(self.context_agent, feature)
+            self.printer.update_item(
+                "trace_id",
+                f"View trace: https://platform.openai.com/traces/trace?trace_id={trace_id}",
+                is_done=True,
+                hide_checkmark=True,
+            )
+
+            self.printer.update_item("context", "Generating tech context...")
+            with custom_span("Tech context"):
+                context_res = await Runner.run(self.context_agent, feature)
+            self.printer.mark_item_done("context")
             context = context_res.final_output_as(TechContext)
 
-            ux_res = await Runner.run(self.ux_agent, feature)
+            self.printer.update_item("ux", "Creating UX spec...")
+            with custom_span("UX spec"):
+                ux_res = await Runner.run(self.ux_agent, feature)
+            self.printer.mark_item_done("ux")
             ux = ux_res.final_output_as(UXSpec)
 
-            func_res = await Runner.run(self.func_agent, feature)
+            self.printer.update_item("functionality", "Outlining functionality...")
+            with custom_span("Functionality"):
+                func_res = await Runner.run(self.func_agent, feature)
+            self.printer.mark_item_done("functionality")
             functionality = func_res.final_output_as(FunctionalitySpec)
 
-            tech_res = await Runner.run(self.tech_agent, feature)
+            self.printer.update_item("tech_spec", "Drafting tech spec...")
+            with custom_span("Tech spec"):
+                tech_res = await Runner.run(self.tech_agent, feature)
+            self.printer.mark_item_done("tech_spec")
             tech = tech_res.final_output_as(TechSpec)
 
-            acc_res = await Runner.run(self.acceptance_agent, feature)
+            self.printer.update_item("acceptance", "Writing acceptance criteria...")
+            with custom_span("Acceptance criteria"):
+                acc_res = await Runner.run(self.acceptance_agent, feature)
+            self.printer.mark_item_done("acceptance")
             acceptance = acc_res.final_output_as(AcceptanceCriteria)
 
-            est_res = await Runner.run(self.estimation_agent, feature)
+            self.printer.update_item("estimate", "Estimating story size...")
+            with custom_span("Estimate"):
+                est_res = await Runner.run(self.estimation_agent, feature)
+            self.printer.mark_item_done("estimate")
             estimate = est_res.final_output_as(StoryEstimate)
 
-            dor_res = await Runner.run(self.dor_agent, feature)
+            self.printer.update_item("dor_review", "Running DoR review...")
+            with custom_span("DoR review"):
+                dor_res = await Runner.run(self.dor_agent, feature)
+            self.printer.mark_item_done("dor_review")
             dor = dor_res.final_output_as(DoRReview)
 
-            impact_res = await Runner.run(self.impact_agent, feature)
+            self.printer.update_item("impact", "Assessing impact...")
+            with custom_span("Impact assessment"):
+                impact_res = await Runner.run(self.impact_agent, feature)
+            self.printer.mark_item_done("impact")
             impact = impact_res.final_output_as(ImpactAssessment)
 
-            int_res = await Runner.run(self.integration_agent, feature)
+            self.printer.update_item("integration", "Checking integration...")
+            with custom_span("Integration check"):
+                int_res = await Runner.run(self.integration_agent, feature)
+            self.printer.mark_item_done("integration")
             integration = int_res.final_output_as(IntegrationCheck)
+
+            self.printer.end()
 
         return UserStory(
             tech_context=context,


### PR DESCRIPTION
## Summary
- introduce `Printer` helper for user story agents
- show progress in `UserStoryLeadAgent` with `Printer.update_item`
- wrap each step in `custom_span` for tracing

## Testing
- `python -m py_compile agents/poc_1_delivery/user_story_agents/user_story_lead_agent.py agents/poc_1_delivery/user_story_agents/printer.py`

------
https://chatgpt.com/codex/tasks/task_e_685cb5899d408326a12ef984bc4cc26f