### PR TITLE
Add multi-agent user story pipeline with tracing

### DIFF
--- a/pocs/user_story_agent/agent/acceptance_agent.py
+++ b/pocs/user_story_agent/agent/acceptance_agent.py
@@ -1,0 +1,23 @@
+"""Acceptance criteria agent."""
+
+from pathlib import Path
+from pydantic import BaseModel
+from agents import Agent
+
+
+class AcceptanceCriteria(BaseModel):
+    criteria: str
+
+
+def _load_prompt() -> str:
+    path = Path(__file__).resolve().parent.parent / "prompts" / "acceptance_prompt.yaml"
+    with open(path, "r", encoding="utf-8") as f:
+        lines = f.readlines()
+    return "".join(lines[1:]).lstrip()
+
+
+acceptance_agent = Agent(
+    name="AcceptanceCriteriaAgent",
+    instructions=_load_prompt(),
+    output_type=AcceptanceCriteria,
+)

--- a/pocs/user_story_agent/agent/dor_verifier_agent.py
+++ b/pocs/user_story_agent/agent/dor_verifier_agent.py
@@ -1,0 +1,24 @@
+"""Definition of Ready verifier agent."""
+
+from pathlib import Path
+from pydantic import BaseModel
+from agents import Agent
+
+
+class DoRCheck(BaseModel):
+    passes: bool
+    story: str
+
+
+def _load_prompt() -> str:
+    path = Path(__file__).resolve().parent.parent / "prompts" / "dor_verifier_prompt.yaml"
+    with open(path, "r", encoding="utf-8") as f:
+        lines = f.readlines()
+    return "".join(lines[1:]).lstrip()
+
+
+dor_verifier_agent = Agent(
+    name="DoRVerifierAgent",
+    instructions=_load_prompt(),
+    output_type=DoRCheck,
+)

--- a/pocs/user_story_agent/agent/estimate_agent.py
+++ b/pocs/user_story_agent/agent/estimate_agent.py
@@ -1,0 +1,23 @@
+"""Story point estimation agent."""
+
+from pathlib import Path
+from pydantic import BaseModel
+from agents import Agent
+
+
+class StoryPointEstimate(BaseModel):
+    points: int
+
+
+def _load_prompt() -> str:
+    path = Path(__file__).resolve().parent.parent / "prompts" / "estimation_prompt.yaml"
+    with open(path, "r", encoding="utf-8") as f:
+        lines = f.readlines()
+    return "".join(lines[1:]).lstrip()
+
+
+estimate_agent = Agent(
+    name="StorypointEstimatorAgent",
+    instructions=_load_prompt(),
+    output_type=StoryPointEstimate,
+)

--- a/pocs/user_story_agent/agent/impact_agent.py
+++ b/pocs/user_story_agent/agent/impact_agent.py
@@ -1,0 +1,45 @@
+"""Impact assessment agent."""
+
+from pathlib import Path
+from pydantic import BaseModel
+from agents import Agent, function_tool
+
+
+class ImpactSummary(BaseModel):
+    summary: str
+
+
+RESOURCES_DIR = Path(__file__).resolve().parent.parent / "resources"
+BACKLOG_PATH = RESOURCES_DIR / "backlog.md"
+AS_IS_PATH = RESOURCES_DIR / "as_is_design.md"
+CODE_DIR = RESOURCES_DIR / "code"
+
+
+@function_tool(name_override="read_backlog", description_override="Load the project backlog")
+def read_backlog() -> str:
+    return BACKLOG_PATH.read_text(encoding="utf-8")
+
+
+@function_tool(name_override="read_current_design", description_override="Load the current design docs")
+def read_current_design() -> str:
+    return AS_IS_PATH.read_text(encoding="utf-8")
+
+
+@function_tool(name_override="read_code_sample", description_override="Load a code sample file")
+def read_code_sample(filename: str = "sample_module.py") -> str:
+    return (CODE_DIR / filename).read_text(encoding="utf-8")
+
+
+def _load_prompt() -> str:
+    path = Path(__file__).resolve().parent.parent / "prompts" / "impact_prompt.yaml"
+    with open(path, "r", encoding="utf-8") as f:
+        lines = f.readlines()
+    return "".join(lines[1:]).lstrip()
+
+
+impact_agent = Agent(
+    name="ImpactAssessmentAgent",
+    instructions=_load_prompt(),
+    tools=[read_backlog, read_current_design, read_code_sample],
+    output_type=ImpactSummary,
+)

--- a/pocs/user_story_agent/agent/user_story_writer.py
+++ b/pocs/user_story_agent/agent/user_story_writer.py
@@ -21,11 +21,27 @@ class UserStory(BaseModel):
 
 @function_tool(
     name_override="write_user_story",
-    description_override="Combine functional and technical specs into a final user story",
+    description_override=(
+        "Combine UX, functional, and technical specs with A/C, impact and story points"
+    ),
 )
-def write_user_story(functional: str, technical: str) -> str:
+def write_user_story(
+    ux: str,
+    functional: str,
+    technical: str,
+    acceptance: str,
+    impact: str,
+    story_points: str,
+) -> str:
     """Return a markdown user story from the given specs."""
-    return f"## Functional Specification\n{functional}\n\n## Technical Specification\n{technical}"
+    return (
+        f"## UX Specification\n{ux}\n\n"
+        f"## Functional Specification\n{functional}\n\n"
+        f"## Technical Specification\n{technical}\n\n"
+        f"## Acceptance Criteria\n{acceptance}\n\n"
+        f"## Impact Assessment\n{impact}\n\n"
+        f"**Story Points:** {story_points}"
+    )
 
 
 def _load_prompt() -> str:

--- a/pocs/user_story_agent/agent/ux_agent.py
+++ b/pocs/user_story_agent/agent/ux_agent.py
@@ -1,0 +1,25 @@
+"""UX specification agent."""
+
+from pathlib import Path
+from pydantic import BaseModel
+from agents import Agent
+
+
+class UXSpec(BaseModel):
+    """Structured UX specification."""
+
+    spec: str
+
+
+def _load_prompt() -> str:
+    path = Path(__file__).resolve().parent.parent / "prompts" / "ux_prompt.yaml"
+    with open(path, "r", encoding="utf-8") as f:
+        lines = f.readlines()
+    return "".join(lines[1:]).lstrip()
+
+
+ux_agent = Agent(
+    name="UXAgent",
+    instructions=_load_prompt(),
+    output_type=UXSpec,
+)

--- a/pocs/user_story_agent/deliverylead.py
+++ b/pocs/user_story_agent/deliverylead.py
@@ -10,21 +10,24 @@ from __future__ import annotations
 
 from rich.console import Console
 
-from agents import Agent, Runner, trace
+from agents import Agent, Runner, gen_trace_id, trace
 from agents.extensions.visualization import draw_graph
 
 from .agent.functional_agent import FunctionalSpec, functional_agent
 from .agent.technical_agent import TechnicalSpec, technical_agent
+from .agent.ux_agent import UXSpec, ux_agent
+from .agent.acceptance_agent import AcceptanceCriteria, acceptance_agent
+from .agent.impact_agent import ImpactSummary, impact_agent
+from .agent.estimate_agent import StoryPointEstimate, estimate_agent
+from .agent.dor_verifier_agent import DoRCheck, dor_verifier_agent
 from .agent.user_story_writer import UserStory, user_story_writer_agent
 from .printer import Printer
 
 
 DELIVERY_PROMPT = (
-    "You are a software delivery lead. When given a feature description, "
-    "first delegate to the FunctionalSpecAgent to produce a functional "
-    "specification. Then delegate to the TechnicalSpecAgent to convert that "
-    "functional spec into a technical specification. Finally delegate to the "
-    "UserStoryWriterAgent to produce the final user story document."
+    "You are a software delivery lead. Given a feature description you "
+    "delegate to UX, functional, technical, acceptance, impact, estimation, "
+    "story writing and DoR verification agents to produce a ready user story."
 )
 
 
@@ -32,7 +35,16 @@ DELIVERY_PROMPT = (
 delivery_lead_agent = Agent(
     name="DeliveryLeadAgent",
     instructions=DELIVERY_PROMPT,
-    handoffs=[functional_agent, technical_agent, user_story_writer_agent],
+    handoffs=[
+        ux_agent,
+        functional_agent,
+        technical_agent,
+        acceptance_agent,
+        impact_agent,
+        estimate_agent,
+        user_story_writer_agent,
+        dor_verifier_agent,
+    ],
     output_type=UserStory,
 )
 
@@ -45,27 +57,88 @@ class DeliveryLeadManager:
         self.printer = Printer(self.console)
 
     async def run(self, feature: str) -> UserStory:
-        with trace("functional_spec"):
-            self.printer.update_item("functional", "Generating functional spec...")
-            func_result = await Runner.run(functional_agent, feature)
-            functional = func_result.final_output_as(FunctionalSpec)
-            self.printer.update_item("functional", functional.spec, is_done=True)
-
-        with trace("technical_spec"):
-            self.printer.update_item("technical", "Generating technical spec...")
-            tech_result = await Runner.run(technical_agent, functional.spec)
-            technical = tech_result.final_output_as(TechnicalSpec)
-            self.printer.update_item("technical", technical.spec, is_done=True)
-
-        with trace("user_story"):
-            self.printer.update_item("story", "Writing user story...")
-            input_data = (
-                f"Functional specification:\n{functional.spec}\n\n"
-                f"Technical specification:\n{technical.spec}"
+        trace_id = gen_trace_id()
+        with trace("user_story_pipeline", trace_id=trace_id):
+            self.printer.update_item(
+                "trace_id",
+                f"View trace: https://platform.openai.com/traces/trace?trace_id={trace_id}",
+                is_done=True,
+                hide_checkmark=True,
             )
-            story_result = await Runner.run(user_story_writer_agent, input_data)
-            story = story_result.final_output_as(UserStory)
-            self.printer.update_item("story", "User story complete", is_done=True)
+            print(f"https://platform.openai.com/traces/trace?trace_id={trace_id}")
+
+            with trace("ux_spec"):
+                self.printer.update_item("ux", "Generating UX spec...")
+                ux_result = await Runner.run(ux_agent, feature)
+                ux = ux_result.final_output_as(UXSpec)
+                self.printer.update_item("ux", ux.spec, is_done=True)
+
+            with trace("functional_spec"):
+                self.printer.update_item("functional", "Generating functional spec...")
+                func_input = f"Feature: {feature}\nUX spec:\n{ux.spec}"
+                func_result = await Runner.run(functional_agent, func_input)
+                functional = func_result.final_output_as(FunctionalSpec)
+                self.printer.update_item("functional", functional.spec, is_done=True)
+
+            with trace("technical_spec"):
+                self.printer.update_item("technical", "Generating technical spec...")
+                tech_result = await Runner.run(technical_agent, functional.spec)
+                technical = tech_result.final_output_as(TechnicalSpec)
+                self.printer.update_item("technical", technical.spec, is_done=True)
+
+            with trace("acceptance_criteria"):
+                self.printer.update_item("acceptance", "Writing acceptance criteria...")
+                acc_input = (
+                    f"Functional specification:\n{functional.spec}\n\n"
+                    f"Technical specification:\n{technical.spec}"
+                )
+                acc_result = await Runner.run(acceptance_agent, acc_input)
+                acceptance = acc_result.final_output_as(AcceptanceCriteria)
+                self.printer.update_item("acceptance", acceptance.criteria, is_done=True)
+
+            with trace("impact_assessment"):
+                self.printer.update_item("impact", "Assessing impact...")
+                impact_input = (
+                    f"Functional specification:\n{functional.spec}\n\n"
+                    f"Technical specification:\n{technical.spec}"
+                )
+                impact_result = await Runner.run(impact_agent, impact_input)
+                impact = impact_result.final_output_as(ImpactSummary)
+                self.printer.update_item("impact", impact.summary, is_done=True)
+
+            with trace("storypoint_estimate"):
+                self.printer.update_item("estimate", "Estimating story points...")
+                est_result = await Runner.run(estimate_agent, impact.summary)
+                estimate = est_result.final_output_as(StoryPointEstimate)
+                self.printer.update_item("estimate", str(estimate.points), is_done=True)
+
+            with trace("user_story"):
+                self.printer.update_item("story", "Writing user story...")
+                story_input = (
+                    f"UX spec:\n{ux.spec}\n\n"
+                    f"Functional spec:\n{functional.spec}\n\n"
+                    f"Technical spec:\n{technical.spec}\n\n"
+                    f"Acceptance criteria:\n{acceptance.criteria}\n\n"
+                    f"Impact:\n{impact.summary}\n\n"
+                    f"Story points: {estimate.points}"
+                )
+                story_result = await Runner.run(user_story_writer_agent, story_input)
+                story = story_result.final_output_as(UserStory)
+                self.printer.update_item("story", "Story drafted", is_done=True)
+
+            passes = False
+            while not passes:
+                with trace("dor_verification"):
+                    self.printer.update_item("dor", "Checking DoR...")
+                    dor_result = await Runner.run(dor_verifier_agent, story.story)
+                    dor = dor_result.final_output_as(DoRCheck)
+                    passes = dor.passes
+                    story.story = dor.story
+                    if not passes:
+                        self.printer.update_item("dor", "Story failed DoR, rewriting...")
+                    else:
+                        self.printer.update_item("dor", "DoR passed", is_done=True)
+
             self.printer.end()
             return story
 

--- a/pocs/user_story_agent/prompts/acceptance_prompt.yaml
+++ b/pocs/user_story_agent/prompts/acceptance_prompt.yaml
@@ -1,0 +1,2 @@
+prompt: |
+  You are a QA engineer. Using the functional and technical specifications, write Gherkin-style acceptance criteria.

--- a/pocs/user_story_agent/prompts/dor_verifier_prompt.yaml
+++ b/pocs/user_story_agent/prompts/dor_verifier_prompt.yaml
@@ -1,0 +1,2 @@
+prompt: |
+  You are a Definition of Ready checker. Review the user story and determine if it meets standard DoR criteria. If not, rewrite it so that it does and set `passes` to false. Provide the updated story in all cases.

--- a/pocs/user_story_agent/prompts/estimation_prompt.yaml
+++ b/pocs/user_story_agent/prompts/estimation_prompt.yaml
@@ -1,0 +1,2 @@
+prompt: |
+  You are a scrum master. Given the impact assessment, estimate the story points using the Fibonacci scale (1,2,3,5,8,13,21).

--- a/pocs/user_story_agent/prompts/impact_prompt.yaml
+++ b/pocs/user_story_agent/prompts/impact_prompt.yaml
@@ -1,0 +1,2 @@
+prompt: |
+  You are a change analyst. Considering the functional specification, technical specification, and project context, summarize the expected impact to code and documentation.

--- a/pocs/user_story_agent/prompts/user_story_writer.yaml
+++ b/pocs/user_story_agent/prompts/user_story_writer.yaml
@@ -1,4 +1,3 @@
 prompt: |
   You are a delivery lead who writes final user stories.
-  Combine the provided functional and technical specifications into a clear
-  markdown user story with acceptance criteria.
+  Combine the provided UX, functional, and technical specifications along with acceptance criteria, impact assessment, and story point estimate into a clear markdown user story.

--- a/pocs/user_story_agent/prompts/ux_prompt.yaml
+++ b/pocs/user_story_agent/prompts/ux_prompt.yaml
@@ -1,0 +1,2 @@
+prompt: |
+  You are a UX designer. Given a feature description, outline the target personas and main user journeys in a concise specification.

--- a/pocs/user_story_agent/resources/as_is_design.md
+++ b/pocs/user_story_agent/resources/as_is_design.md
@@ -1,0 +1,3 @@
+# As-Is Design
+The authentication service currently supports only email/password login.
+Frontend uses React forms and session cookies.

--- a/pocs/user_story_agent/resources/backlog.md
+++ b/pocs/user_story_agent/resources/backlog.md
@@ -1,0 +1,4 @@
+# Current Backlog
+- Add OAuth login support
+- Improve dashboard performance
+- Refactor notification system

--- a/pocs/user_story_agent/resources/code/sample_module.py
+++ b/pocs/user_story_agent/resources/code/sample_module.py
@@ -1,0 +1,5 @@
+"""Existing login module"""
+
+def existing_login(user, password):
+    """Placeholder existing login function."""
+    pass


### PR DESCRIPTION
## Summary
- add UX, acceptance, impact, estimation and DoR agents
- update user_story_writer agent to accept all new specs
- extend delivery lead manager with global trace and DoR loop
- include reference backlog, design and sample code resources
- provide prompts for all new agents

## Testing
- `bash pocs/user_story_agent/test/run_test.sh` *(fails: OPENAI_API_KEY not set)*

------
https://chatgpt.com/codex/tasks/task_e_685d75647ae48326b6db542943c46277