### PR TITLE
Add aggregate result model to delivery lead workflow

### DIFF
--- a/pocs/user_story_agent/main.py
+++ b/pocs/user_story_agent/main.py
@@ -17,9 +17,9 @@ from .deliverylead import DeliveryLeadManager, visualize_workflow
 async def main() -> None:
     feature = input("Enter a feature description: ")
     mgr = DeliveryLeadManager()
-    story = await mgr.run(feature)
+    result = await mgr.run(feature)
     print("\n--- User Story ---\n")
-    print(story.story)
+    print(result.story.story)
 
     output_dir = Path(__file__).resolve().parent / "outputs"
     output_dir.mkdir(exist_ok=True)
@@ -28,7 +28,7 @@ async def main() -> None:
     with open(story_file, "w", encoding="utf-8") as f:
         f.write("# Feature Input\n")
         f.write(feature + "\n\n")
-        f.write(story.story)
+        f.write(result.story.story)
 
     visualize_workflow(filename=str(output_dir / f"workflow_{timestamp}.png"))
 


### PR DESCRIPTION
## Summary
- implement `UserStoryPipelineOutput` for user story pipeline results
- return this structured model from `DeliveryLeadManager.run`
- adjust CLI entrypoint to handle the new return type

## Testing
- `bash pocs/user_story_agent/test/run_test.sh` *(fails: OpenAI API key missing)*
- `bash pocs/run_coach_agent/test/run_test.sh` *(fails: OpenAI API key missing)*

------
https://chatgpt.com/codex/tasks/task_e_685da0628a288326bcb326179be779c2