### PR TITLE
Improve run coach pipeline output

### DIFF
--- a/pocs/run_coach_agent/agent/goal_agent.py
+++ b/pocs/run_coach_agent/agent/goal_agent.py
@@ -1,8 +1,9 @@
 """GoalRaceAgent converts a free form race description into structured data."""
 
 from pathlib import Path
+from datetime import datetime
 from pydantic import BaseModel
-from agents import Agent
+from agents import Agent, function_tool
 
 
 class RaceGoal(BaseModel):
@@ -22,8 +23,15 @@ def _load_prompt() -> str:
     return "".join(lines[1:]).lstrip()
 
 
+@function_tool
+def get_current_date() -> str:
+    """Return today's date in ISO format."""
+    return datetime.now().date().isoformat()
+
+
 goal_agent = Agent(
     name="GoalRaceAgent",
     instructions=_load_prompt(),
+    tools=[get_current_date],
     output_type=RaceGoal,
 )

--- a/pocs/run_coach_agent/main.py
+++ b/pocs/run_coach_agent/main.py
@@ -15,19 +15,30 @@ from .runcoach import RunCoachManager, visualize_workflow
 async def main() -> None:
     goal = input("Describe your race goal: ")
     mgr = RunCoachManager()
-    plan = await mgr.run(goal)
+    result = await mgr.run(goal)
 
     print("\n--- Training Plan ---\n")
-    print(plan.plan)
+    print(result.plan.plan)
 
     output_dir = Path(__file__).resolve().parent / "outputs"
     output_dir.mkdir(exist_ok=True)
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
     plan_file = output_dir / f"plan_{timestamp}.md"
     with open(plan_file, "w", encoding="utf-8") as f:
-        f.write("# Goal\n")
+        f.write("# Your Race Input\n")
         f.write(goal + "\n\n")
-        f.write(plan.plan)
+
+        f.write("# Race Goal\n")
+        f.write(str(result.goal) + "\n\n")
+
+        f.write("# Current Run Stats\n")
+        f.write(result.runs.csv + "\n\n")
+
+        f.write("# Run Analysis\n")
+        f.write(result.analysis.analysis + "\n\n")
+
+        f.write("# Training Plan\n")
+        f.write(result.plan.plan)
 
     visualize_workflow(filename=str(output_dir / f"workflow_{timestamp}.png"))
 


### PR DESCRIPTION
## Summary
- add `get_current_date` tool for goal agent
- return full pipeline data from `RunCoachManager`
- write intermediate outputs to markdown file
- inject current date when parsing goal

## Testing
- `bash pocs/run_coach_agent/test/run_test.sh` *(fails: OpenAI API key not set)*

------
https://chatgpt.com/codex/tasks/task_e_685da83864b48326b3d307630ccb4ae1