### PR TITLE
Add guardrails for TripPlannerAgent

### DIFF
--- a/pocs/trip_planner_agent/agent/guardrails.py
+++ b/pocs/trip_planner_agent/agent/guardrails.py
@@ -1,0 +1,77 @@
+"""Guardrail functions for TripPlannerAgent."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from pydantic import BaseModel
+from agents import (
+    Agent,
+    GuardrailFunctionOutput,
+    RunContextWrapper,
+    Runner,
+    TResponseInputItem,
+    input_guardrail,
+    output_guardrail,
+)
+
+
+def _load_prompt(filename: str) -> str:
+    path = Path(__file__).resolve().parent.parent / "prompts" / filename
+    with open(path, "r", encoding="utf-8") as f:
+        lines = f.readlines()
+    return "".join(lines[1:]).lstrip()
+
+
+class GuardrailDecision(BaseModel):
+    """Common structure for guardrail agents."""
+
+    flagged: bool
+    reason: str
+
+
+# Helper guardrail agents
+input_check_agent = Agent(
+    name="Trip Input Check",
+    instructions=_load_prompt("guardrail_input_check.yaml"),
+    output_type=GuardrailDecision,
+)
+
+output_check_agent = Agent(
+    name="Trip Output Check",
+    instructions=_load_prompt("guardrail_output_check.yaml"),
+    output_type=GuardrailDecision,
+)
+
+
+class TripOutput(BaseModel):
+    """Wrapper for planner output when validating."""
+
+    response: str
+
+
+@input_guardrail
+async def vague_trip_guardrail(
+    ctx: RunContextWrapper[None],
+    agent: Agent,
+    input: str | list[TResponseInputItem],
+) -> GuardrailFunctionOutput:
+    result = await Runner.run(input_check_agent, input, context=ctx.context)
+    decision = result.final_output_as(GuardrailDecision)
+    return GuardrailFunctionOutput(
+        output_info=decision,
+        tripwire_triggered=decision.flagged,
+    )
+
+
+@output_guardrail
+async def trip_quality_guardrail(
+    ctx: RunContextWrapper[None],
+    agent: Agent,
+    output: TripOutput,
+) -> GuardrailFunctionOutput:
+    result = await Runner.run(output_check_agent, output.response, context=ctx.context)
+    decision = result.final_output_as(GuardrailDecision)
+    return GuardrailFunctionOutput(
+        output_info=decision,
+        tripwire_triggered=decision.flagged,
+    )

--- a/pocs/trip_planner_agent/agent/planner_agent.py
+++ b/pocs/trip_planner_agent/agent/planner_agent.py
@@ -2,13 +2,13 @@
 from pathlib import Path
 from pydantic import BaseModel
 from agents import Agent
+from .guardrails import TripOutput, trip_quality_guardrail
 
 
-class TripPlan(BaseModel):
-    """Final travel plan."""
+class TripOutput(BaseModel):
+    """Final travel plan response."""
 
-    summary: str
-    itinerary: str
+    response: str
 
 
 def _load_prompt() -> str:
@@ -21,5 +21,6 @@ def _load_prompt() -> str:
 planner_agent = Agent(
     name="PlannerAgent",
     instructions=_load_prompt(),
-    output_type=TripPlan,
+    output_type=TripOutput,
+    output_guardrails=[trip_quality_guardrail],
 )

--- a/pocs/trip_planner_agent/agent/topic_agent.py
+++ b/pocs/trip_planner_agent/agent/topic_agent.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from datetime import datetime
 from pydantic import BaseModel
 from agents import Agent, function_tool
+from .guardrails import vague_trip_guardrail
 
 
 class ResearchTopic(BaseModel):
@@ -37,4 +38,5 @@ topic_agent = Agent(
     instructions=_load_prompt(),
     tools=[get_current_date],
     output_type=ResearchPlan,
+    input_guardrails=[vague_trip_guardrail],
 )

--- a/pocs/trip_planner_agent/main.py
+++ b/pocs/trip_planner_agent/main.py
@@ -10,16 +10,30 @@ import asyncio
 from datetime import datetime
 from pathlib import Path
 
+from agents.exceptions import (
+    InputGuardrailTripwireTriggered,
+    OutputGuardrailTripwireTriggered,
+)
+
 from .tripmanager import TripPlanningManager, visualize_workflow
 
 
 async def main() -> None:
     goal = input("Describe your trip goals: ")
     mgr = TripPlanningManager()
-    result = await mgr.run(goal)
+    try:
+        result = await mgr.run(goal)
+    except InputGuardrailTripwireTriggered as exc:
+        info = exc.guardrail_result.output.output_info
+        print(f"\nInput rejected: {getattr(info, 'reason', '')}")
+        return
+    except OutputGuardrailTripwireTriggered as exc:
+        info = exc.guardrail_result.output.output_info
+        print(f"\nInvalid itinerary: {getattr(info, 'reason', '')}")
+        return
 
     print("\n--- Trip Itinerary ---\n")
-    print(result.plan.itinerary)
+    print(result.plan.response)
 
     output_dir = Path(__file__).resolve().parent / "outputs"
     output_dir.mkdir(exist_ok=True)
@@ -39,7 +53,7 @@ async def main() -> None:
             f.write(r.summary + "\n\n")
 
         f.write("# Trip Plan\n")
-        f.write(result.plan.itinerary)
+        f.write(result.plan.response)
 
     visualize_workflow(filename=str(output_dir / f"workflow_{timestamp}.png"))
 

--- a/pocs/trip_planner_agent/prompts/guardrail_input_check.yaml
+++ b/pocs/trip_planner_agent/prompts/guardrail_input_check.yaml
@@ -1,0 +1,3 @@
+prompt: |
+  You are a trip request safety checker. Determine if the user's request is too vague, unsafe, or not actionable for planning.
+  Respond in JSON with fields `flagged` (true if problematic) and `reason` describing your assessment.

--- a/pocs/trip_planner_agent/prompts/guardrail_output_check.yaml
+++ b/pocs/trip_planner_agent/prompts/guardrail_output_check.yaml
@@ -1,0 +1,3 @@
+prompt: |
+  Review the itinerary for specificity, realism, and safety. Confirm that it lists destinations, activities, transportation, and accommodations.
+  Respond in JSON with fields `flagged` (true if the plan is low quality or unsafe) and `reason` explaining your judgment.


### PR DESCRIPTION
## Summary
- add guardrail agent definitions and functions
- validate vague input on `TopicAgent`
- validate itinerary quality on `PlannerAgent`
- update manager and CLI for new `TripOutput` schema
- add guardrail prompts for input and output checks
- catch guardrail exceptions when running the CLI

## Testing
- `pocs/trip_planner_agent/test/run_test.sh` *(fails: OPENAI_API_KEY not set)*

------
https://chatgpt.com/codex/tasks/task_e_685dbb9b6a4c83269baf8ad64dc77e4e