### PR TITLE
Add README docs for agent PoCs

### DIFF
--- a/pocs/run_coach_agent/README.md
+++ b/pocs/run_coach_agent/README.md
@@ -1,0 +1,45 @@
+# Run Coach Agent PoC
+
+This proof of concept creates a personalized running plan using a small team of agents. It reads your recent Garmin `Activities.csv` and a free form race goal, then outputs a week‑by‑week training schedule.
+
+## Target users
+- Recreational runners preparing for an upcoming race
+- Anyone wanting a quick assessment of their current running stats
+
+## Benefits
+- Automatically analyzes your latest runs
+- Produces an achievable plan tailored to your race date and pace goal
+- Saves the plan and a workflow diagram for later review
+
+## Pipeline overview
+1. **Goal Agent** – parses the race description into distance, date and pace targets
+2. **Collect Agent** – loads recent runs from `Activities.csv`
+3. **Analyze Agent** – finds training strengths and gaps
+4. **Plan Agent** – writes a week‑by‑week schedule
+5. **Check Agent** – validates the plan and revises if needed
+
+Each stage prints progress to the console so you can see the goal, collected data, analysis and final plan.
+
+## Inputs and outputs
+- **Input:** a text description of your race goal and the Garmin CSV located in `resources/Activities.csv`
+- **Output:** the final training plan in the console and a markdown file under `outputs/` along with a workflow image
+
+## Future enhancements
+- Support other fitness data sources such as Strava
+- Add injury risk detection and calendar export
+- Offer multiple plan strategies based on user experience
+
+## Running
+Install dependencies then execute:
+
+```bash
+python -m pocs.run_coach_agent.main
+```
+
+You can try the sample goal with:
+
+```bash
+python -m pocs.run_coach_agent.main < pocs/run_coach_agent/test/sample_goal.txt
+```
+
+Your plan and diagram will be saved in `pocs/run_coach_agent/outputs/`.

--- a/pocs/trip_planner_agent/README.md
+++ b/pocs/trip_planner_agent/README.md
@@ -1,0 +1,43 @@
+# Trip Planner Agent PoC
+
+This proof of concept assembles a short travel itinerary from a free form trip request. The agent team researches points of interest and compiles a day‑by‑day plan.
+
+## Target users
+- Travelers looking for quick suggestions on what to see and do
+- Anyone wanting a structured plan from minimal input
+
+## Benefits
+- Automatically searches the web for relevant attractions
+- Generates a concise itinerary including transportation and lodging tips
+- Rejects vague requests and checks the final plan for quality and safety
+
+## Pipeline overview
+1. **Topic Agent** – extracts 3–5 research topics from the trip goal
+2. **Research Agent** – searches the web for each topic and summarizes results
+3. **Planner Agent** – writes the itinerary and passes it through output guardrails
+
+Progress is printed to the console so you can view topics, research summaries and the final itinerary.
+
+## Inputs and outputs
+- **Input:** a text description of your travel goals
+- **Output:** a markdown itinerary printed to the console and saved under `outputs/` along with a workflow image
+
+## Future enhancements
+- Add budget estimates and restaurant recommendations
+- Integrate map links and calendar exports
+- Support alternate planning modes like backpacking or luxury travel
+
+## Running
+Install dependencies then run:
+
+```bash
+python -m pocs.trip_planner_agent.main
+```
+
+To try the sample input:
+
+```bash
+python -m pocs.trip_planner_agent.main < pocs/trip_planner_agent/test/sample_input.txt
+```
+
+The generated plan and diagram appear in `pocs/trip_planner_agent/outputs/`.

--- a/pocs/user_story_agent/README.md
+++ b/pocs/user_story_agent/README.md
@@ -1,28 +1,36 @@
 # User Story Agent PoC
 
-This Proof of Concept converts a short feature request into a Definition of Ready compliant user story using the OpenAI Agents SDK. A Delivery Lead agent orchestrates a sequence of specialized sub-agents to produce intermediate specifications and the final story.
+This proof of concept turns a short feature request into a Definition of Ready compliant user story. A Delivery Lead agent coordinates several specialized agents to gather specifications and write the final story.
 
-## Pipeline
+## Target users
+- Product owners or delivery leads who need consistent user stories
+- Developers exploring automated requirements generation
 
-1. **UX Agent** – outlines target personas and user journeys.
-2. **Functional Agent** – writes functional requirements based on the feature and UX spec.
-3. **Technical Agent** – generates a technical specification using the reference architecture.
-4. **Acceptance Agent** – drafts Gherkin-style acceptance criteria.
-5. **Impact Agent** – summarizes code and documentation impact.
-6. **Estimation Agent** – estimates story points with the Fibonacci scale.
-7. **User Story Writer** – combines all specs into a markdown user story.
-8. **DoR Verifier** – iteratively checks the story against the Definition of Ready.
+## Benefits
+- Quickly expands a one‑line feature request into UX, functional and technical specs
+- Provides acceptance criteria and impact analysis
+- Iteratively checks that the resulting story meets your Definition of Ready
 
-Each stage prints its output to the console so you can see the UX, functional, technical, acceptance, impact and estimation results before the final story is displayed.
+## Pipeline overview
+1. **UX Agent** – outlines target personas and user journeys
+2. **Functional Agent** – writes functional requirements using the UX spec
+3. **Technical Agent** – generates a technical design using the reference architecture
+4. **Acceptance Agent** – drafts Gherkin‑style acceptance criteria
+5. **Impact Agent** – summarizes code and documentation impact
+6. **Estimation Agent** – estimates story points with the Fibonacci scale
+7. **User Story Writer** – combines all specs into a markdown user story
+8. **DoR Verifier** – revises the story until it passes the Definition of Ready
 
-## Files
-- `main.py` – entry point that runs the pipeline
-- `deliverylead.py` – orchestrates the agents above
-- `agent/` – individual agent modules
-- `prompts/` – YAML prompt templates
-- `resources/tech_architecture.md` – reference architecture for the technical agent
-- `outputs/` – saved user stories and workflow images
-- `test/` – sample input and a simple test runner
+Progress for each stage is printed to the console so you can review the intermediate specs.
+
+## Inputs and outputs
+- **Input:** a brief feature description and the technical architecture file in `resources/`
+- **Output:** the final user story printed to the console and saved under `outputs/` with a workflow image and all intermediate specs
+
+## Future enhancements
+- Link directly to issue trackers for story creation
+- Add a persona repository for richer UX guidance
+- Provide optional code scaffolding based on the technical spec
 
 ## Running
 Install dependencies and run:
@@ -31,10 +39,10 @@ Install dependencies and run:
 python -m pocs.user_story_agent.main
 ```
 
-You can also provide the sample input:
+Try the sample feature description with:
 
 ```bash
 python -m pocs.user_story_agent.main < pocs/user_story_agent/test/sample_input.txt
 ```
 
-During execution all intermediate specs and the final user story are printed. The results are saved in `pocs/user_story_agent/outputs/` as a timestamped markdown file and a workflow diagram image.
+The generated story and diagram are saved in `pocs/user_story_agent/outputs/`.


### PR DESCRIPTION
## Summary
- add docs for run coach and trip planner agents
- expand user story agent README with more details

## Testing
- `bash pocs/run_coach_agent/test/run_test.sh` *(fails: OPENAI_API_KEY missing)*
- `bash pocs/trip_planner_agent/test/run_test.sh` *(fails: OPENAI_API_KEY missing)*
- `bash pocs/user_story_agent/test/run_test.sh` *(fails: OPENAI_API_KEY missing)*

------
https://chatgpt.com/codex/tasks/task_e_685dfc7483b88326a343aa992bdd9938