### PR TITLE
Add input guardrails for UserStory and RunCoach agents

### DIFF
--- a/pocs/run_coach_agent/agent/goal_agent.py
+++ b/pocs/run_coach_agent/agent/goal_agent.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from datetime import datetime
 from pydantic import BaseModel
 from agents import Agent, function_tool
+from .guardrails import race_goal_guardrail
 
 
 class RaceGoal(BaseModel):
@@ -34,4 +35,5 @@ goal_agent = Agent(
     instructions=_load_prompt(),
     tools=[get_current_date],
     output_type=RaceGoal,
+    input_guardrails=[race_goal_guardrail],
 )

--- a/pocs/run_coach_agent/agent/guardrails.py
+++ b/pocs/run_coach_agent/agent/guardrails.py
@@ -1,0 +1,49 @@
+"""Guardrail functions for RunCoachAgent."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from pydantic import BaseModel
+from agents import (
+    Agent,
+    GuardrailFunctionOutput,
+    RunContextWrapper,
+    Runner,
+    TResponseInputItem,
+    input_guardrail,
+)
+
+
+def _load_prompt(filename: str) -> str:
+    path = Path(__file__).resolve().parents[3] / "prompts" / "guardrails" / filename
+    with open(path, "r", encoding="utf-8") as f:
+        lines = f.readlines()
+    return "".join(lines[1:]).lstrip()
+
+
+class GuardrailDecision(BaseModel):
+    """Common structure for guardrail agents."""
+
+    flagged: bool
+    reason: str
+
+
+goal_check_agent = Agent(
+    name="Race Goal Input Check",
+    instructions=_load_prompt("goal_input_check.yaml"),
+    output_type=GuardrailDecision,
+)
+
+
+@input_guardrail
+async def race_goal_guardrail(
+    ctx: RunContextWrapper[None],
+    agent: Agent,
+    input: str | list[TResponseInputItem],
+) -> GuardrailFunctionOutput:
+    result = await Runner.run(goal_check_agent, input, context=ctx.context)
+    decision = result.final_output_as(GuardrailDecision)
+    return GuardrailFunctionOutput(
+        output_info=decision,
+        tripwire_triggered=decision.flagged,
+    )

--- a/pocs/user_story_agent/agent/guardrails.py
+++ b/pocs/user_story_agent/agent/guardrails.py
@@ -1,0 +1,49 @@
+"""Guardrail functions for UserStoryAgent."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from pydantic import BaseModel
+from agents import (
+    Agent,
+    GuardrailFunctionOutput,
+    RunContextWrapper,
+    Runner,
+    TResponseInputItem,
+    input_guardrail,
+)
+
+
+def _load_prompt(filename: str) -> str:
+    path = Path(__file__).resolve().parents[3] / "prompts" / "guardrails" / filename
+    with open(path, "r", encoding="utf-8") as f:
+        lines = f.readlines()
+    return "".join(lines[1:]).lstrip()
+
+
+class GuardrailDecision(BaseModel):
+    """Common structure for guardrail agents."""
+
+    flagged: bool
+    reason: str
+
+
+feature_check_agent = Agent(
+    name="Feature Input Check",
+    instructions=_load_prompt("user_story_input_check.yaml"),
+    output_type=GuardrailDecision,
+)
+
+
+@input_guardrail
+async def vague_feature_guardrail(
+    ctx: RunContextWrapper[None],
+    agent: Agent,
+    input: str | list[TResponseInputItem],
+) -> GuardrailFunctionOutput:
+    result = await Runner.run(feature_check_agent, input, context=ctx.context)
+    decision = result.final_output_as(GuardrailDecision)
+    return GuardrailFunctionOutput(
+        output_info=decision,
+        tripwire_triggered=decision.flagged,
+    )

--- a/pocs/user_story_agent/agent/ux_agent.py
+++ b/pocs/user_story_agent/agent/ux_agent.py
@@ -3,6 +3,7 @@
 from pathlib import Path
 from pydantic import BaseModel
 from agents import Agent
+from .guardrails import vague_feature_guardrail
 
 
 class UXSpec(BaseModel):
@@ -22,4 +23,5 @@ ux_agent = Agent(
     name="UXAgent",
     instructions=_load_prompt(),
     output_type=UXSpec,
+    input_guardrails=[vague_feature_guardrail],
 )

--- a/prompts/guardrails/goal_input_check.yaml
+++ b/prompts/guardrails/goal_input_check.yaml
@@ -1,0 +1,5 @@
+prompt: |
+  You are a running coach validating a race goal description.
+  Verify the race type, date, and time goal are clearly specified.
+  Flag unrealistic, ambiguous, or improperly formatted requests.
+  Respond in JSON with fields `flagged` and `reason` summarizing any issues.

--- a/prompts/guardrails/user_story_input_check.yaml
+++ b/prompts/guardrails/user_story_input_check.yaml
@@ -1,0 +1,5 @@
+prompt: |
+  You are a software planning assistant verifying a new feature request.
+  Determine if the feature description is vague, generic, or not actionable for planning.
+  Also flag requests that are out of scope or unsupported.
+  Respond in JSON with fields `flagged` (true if problematic) and `reason` explaining your judgment.


### PR DESCRIPTION
## Summary
- implement input guardrail logic for UX and Goal agents
- create guardrail prompts for vague feature requests and race goals
- connect guardrails to UXAgent and GoalRaceAgent

## Testing
- `bash pocs/user_story_agent/test/run_test.sh` *(fails: Timed out while waiting for response to ClientRequest)*
- `bash pocs/run_coach_agent/test/run_test.sh` *(fails: OPENAI_API_KEY environment variable not set)*

------
https://chatgpt.com/codex/tasks/task_e_685e0bfabb248326949af675a6597fc7