### PR TITLE
Add LiteLLM model selection

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -1,1 +1,3 @@
 OPENAI_API_KEY=your-api-key-here
+MODEL=openai/gpt-4o
+MODEL_API_KEY=sk-xxx

--- a/pocs/run_coach_agent/main.py
+++ b/pocs/run_coach_agent/main.py
@@ -5,17 +5,29 @@ Requirements:
 - Run with `python -m pocs.run_coach_agent.main` and enter a race goal when prompted.
 """
 
+import argparse
 import asyncio
+import os
 from datetime import datetime
 from pathlib import Path
 
 from agents.exceptions import InputGuardrailTripwireTriggered
+from agents.extensions.models.litellm_model import LitellmModel
 from .runcoach import RunCoachManager, visualize_workflow
 
 
 async def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model", type=str, help="Model to use (e.g. openai/gpt-4o)")
+    parser.add_argument("--api-key", type=str, help="API key for the model")
+    args = parser.parse_args()
+
+    model_name = args.model if args.model else os.environ["MODEL"]
+    api_key = args.api_key if args.api_key else os.environ["MODEL_API_KEY"]
+    model = LitellmModel(model=model_name, api_key=api_key)
+
     goal = input("Describe your race goal: ")
-    mgr = RunCoachManager()
+    mgr = RunCoachManager(model=model)
     try:
         result = await mgr.run(goal)
     except InputGuardrailTripwireTriggered as exc:

--- a/pocs/run_coach_agent/runcoach.py
+++ b/pocs/run_coach_agent/runcoach.py
@@ -42,9 +42,20 @@ class RunCoachPipelineOutput(BaseModel):
 class RunCoachManager:
     """Sequentially execute the run coach pipeline."""
 
-    def __init__(self) -> None:
+    def __init__(self, model=None) -> None:
         self.console = Console()
         self.printer = Printer(self.console)
+        self.model = model
+        if model is not None:
+            for agent in [
+                goal_agent,
+                collect_agent,
+                analyze_agent,
+                plan_agent,
+                check_agent,
+                run_coach_agent,
+            ]:
+                agent.model = model
 
     async def run(self, goal_description: str) -> RunCoachPipelineOutput:
         trace_id = gen_trace_id()

--- a/pocs/trip_planner_agent/main.py
+++ b/pocs/trip_planner_agent/main.py
@@ -6,7 +6,9 @@ Requirements:
   trip goals or pipe the file as stdin.
 """
 
+import argparse
 import asyncio
+import os
 from datetime import datetime
 from pathlib import Path
 
@@ -15,12 +17,22 @@ from agents.exceptions import (
     OutputGuardrailTripwireTriggered,
 )
 
+from agents.extensions.models.litellm_model import LitellmModel
 from .tripmanager import TripPlanningManager, visualize_workflow
 
 
 async def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model", type=str, help="Model to use (e.g. openai/gpt-4o)")
+    parser.add_argument("--api-key", type=str, help="API key for the model")
+    args = parser.parse_args()
+
+    model_name = args.model if args.model else os.environ["MODEL"]
+    api_key = args.api_key if args.api_key else os.environ["MODEL_API_KEY"]
+    model = LitellmModel(model=model_name, api_key=api_key)
+
     goal = input("Describe your trip goals: ")
-    mgr = TripPlanningManager()
+    mgr = TripPlanningManager(model=model)
     try:
         result = await mgr.run(goal)
     except InputGuardrailTripwireTriggered as exc:

--- a/pocs/trip_planner_agent/tripmanager.py
+++ b/pocs/trip_planner_agent/tripmanager.py
@@ -37,9 +37,13 @@ class TripPipelineOutput(BaseModel):
 class TripPlanningManager:
     """Sequentially execute the trip planning pipeline."""
 
-    def __init__(self) -> None:
+    def __init__(self, model=None) -> None:
         self.console = Console()
         self.printer = Printer(self.console)
+        self.model = model
+        if model is not None:
+            for agent in [topic_agent, research_agent, planner_agent, trip_planner_agent]:
+                agent.model = model
 
     async def run(self, goal: str) -> TripPipelineOutput:
         trace_id = gen_trace_id()

--- a/pocs/user_story_agent/agent/impact_agent.py
+++ b/pocs/user_story_agent/agent/impact_agent.py
@@ -19,7 +19,7 @@ def _load_prompt() -> str:
     return "".join(lines[1:]).lstrip()
 
 
-def build_impact_agent(server: MCPServer) -> Agent:
+def build_impact_agent(server: MCPServer, model=None) -> Agent:
     """Create an ImpactAssessmentAgent that can access context files via MCP."""
 
     return Agent(
@@ -27,6 +27,7 @@ def build_impact_agent(server: MCPServer) -> Agent:
         instructions=_load_prompt(),
         mcp_servers=[server],
         output_type=ImpactSummary,
+        model=model,
     )
 
 

--- a/pocs/user_story_agent/main.py
+++ b/pocs/user_story_agent/main.py
@@ -7,7 +7,9 @@ Requirements:
   feature description or pipe the file as stdin.
 """
 
+import argparse
 import asyncio
+import os
 from pathlib import Path
 from datetime import datetime
 
@@ -15,10 +17,20 @@ from agents import gen_trace_id, trace
 from agents.exceptions import InputGuardrailTripwireTriggered
 from agents.mcp import MCPServerStdio
 
+from agents.extensions.models.litellm_model import LitellmModel
 from .deliverylead import DeliveryLeadManager, visualize_workflow
 
 
 async def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model", type=str, help="Model to use (e.g. openai/gpt-4o)")
+    parser.add_argument("--api-key", type=str, help="API key for the model")
+    args = parser.parse_args()
+
+    model_name = args.model if args.model else os.environ["MODEL"]
+    api_key = args.api_key if args.api_key else os.environ["MODEL_API_KEY"]
+    model = LitellmModel(model=model_name, api_key=api_key)
+
     feature = input("Enter a feature description: ")
     context_dir = Path(__file__).resolve().parent / "resources" / "context_files"
 
@@ -28,7 +40,7 @@ async def main() -> None:
     ) as server:
         trace_id = gen_trace_id()
         with trace("user_story_poc", trace_id=trace_id):
-            mgr = DeliveryLeadManager(server)
+            mgr = DeliveryLeadManager(server, model=model)
             try:
                 result = await mgr.run(feature)
             except InputGuardrailTripwireTriggered as exc:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ packages = [
 [tool.poetry.dependencies]
 python = "^3.11"
 openai-agents = {git = "https://github.com/stewmckendry/openai-agents-python.git", extras = ["viz"]}
+litellm = "*"
 
 [build-system]
 requires = ["poetry-core"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ openai-agents[viz] @ git+https://github.com/openai/openai-agents-python.git
 openai
 pydantic
 rich
+litellm


### PR DESCRIPTION
## Summary
- add MODEL and MODEL_API_KEY to `.env-example`
- allow selecting LiteLLM models via CLI for Run Coach, Trip Planner and User Story agents
- propagate model choice through respective managers
- wire up Impact agent to accept a model
- add `litellm` dependency

## Testing
- `MODEL=openai/gpt-4o MODEL_API_KEY=dummykey ./pocs/run_coach_agent/test/run_test.sh` *(fails: ModuleNotFoundError: No module named 'litellm')*
- `MODEL=openai/gpt-4o MODEL_API_KEY=dummykey ./pocs/trip_planner_agent/test/run_test.sh` *(fails: ModuleNotFoundError: No module named 'litellm')*
- `MODEL=openai/gpt-4o MODEL_API_KEY=dummykey ./pocs/user_story_agent/test/run_test.sh` *(fails: ModuleNotFoundError: No module named 'litellm')*

------
https://chatgpt.com/codex/tasks/task_e_685e11d3fdcc8326937011c422e662b6