### PR TITLE
Unify trace IDs in PoC pipelines

### DIFF
--- a/pocs/trip_planner_agent/main.py
+++ b/pocs/trip_planner_agent/main.py
@@ -12,6 +12,7 @@ import os
 from datetime import datetime
 from pathlib import Path
 
+from agents import gen_trace_id, trace
 from agents.exceptions import (
     InputGuardrailTripwireTriggered,
     OutputGuardrailTripwireTriggered,
@@ -33,16 +34,18 @@ async def main() -> None:
 
     goal = input("Describe your trip goals: ")
     mgr = TripPlanningManager(model=model)
-    try:
-        result = await mgr.run(goal)
-    except InputGuardrailTripwireTriggered as exc:
-        info = exc.guardrail_result.output.output_info
-        print(f"\nInput rejected: {getattr(info, 'reason', '')}")
-        return
-    except OutputGuardrailTripwireTriggered as exc:
-        info = exc.guardrail_result.output.output_info
-        print(f"\nInvalid itinerary: {getattr(info, 'reason', '')}")
-        return
+    trace_id = gen_trace_id()
+    with trace("trip_planner_poc", trace_id=trace_id):
+        try:
+            result = await mgr.run(goal, trace_id=trace_id)
+        except InputGuardrailTripwireTriggered as exc:
+            info = exc.guardrail_result.output.output_info
+            print(f"\nInput rejected: {getattr(info, 'reason', '')}")
+            return
+        except OutputGuardrailTripwireTriggered as exc:
+            info = exc.guardrail_result.output.output_info
+            print(f"\nInvalid itinerary: {getattr(info, 'reason', '')}")
+            return
 
     print("\n--- Trip Itinerary ---\n")
     print(result.plan.response)

--- a/pocs/trip_planner_agent/tripmanager.py
+++ b/pocs/trip_planner_agent/tripmanager.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from rich.console import Console
 from pydantic import BaseModel
 
-from agents import Agent, Runner, gen_trace_id, trace
+from agents import Agent, Runner
 from agents.extensions.visualization import draw_graph
 
 from .printer import Printer
@@ -45,10 +45,9 @@ class TripPlanningManager:
             for agent in [topic_agent, research_agent, planner_agent, trip_planner_agent]:
                 agent.model = model
 
-    async def run(self, goal: str) -> TripPipelineOutput:
-        trace_id = gen_trace_id()
+    async def run(self, goal: str, trace_id: str | None = None) -> TripPipelineOutput:
         try:
-            with trace("trip_planner_pipeline", trace_id=trace_id):
+            if trace_id:
                 self.printer.update_item(
                     "trace_id",
                     f"View trace: https://platform.openai.com/traces/trace?trace_id={trace_id}",
@@ -57,35 +56,32 @@ class TripPlanningManager:
                 )
                 print(f"https://platform.openai.com/traces/trace?trace_id={trace_id}")
 
-            with trace("topics"):
-                self.printer.update_item("topics", "Creating research topics...")
-                topics_result = await Runner.run(topic_agent, goal)
-                topics = topics_result.final_output_as(ResearchPlan)
-                self.printer.update_item(
-                    "topics", f"{len(topics.topics)} topics", is_done=True
-                )
+            self.printer.update_item("topics", "Creating research topics...")
+            topics_result = await Runner.run(topic_agent, goal)
+            topics = topics_result.final_output_as(ResearchPlan)
+            self.printer.update_item(
+                "topics", f"{len(topics.topics)} topics", is_done=True
+            )
 
             research_summaries: list[ResearchSummary] = []
-            with trace("research"):
-                self.printer.update_item("research", "Researching topics...")
-                for item in topics.topics:
-                    input_text = (
-                        f"Search term: {item.query}\nReason for searching: {item.reason}"
-                    )
-                    result = await Runner.run(research_agent, input_text)
-                    summary = result.final_output_as(ResearchSummary)
-                    research_summaries.append(summary)
-                self.printer.update_item("research", "Research complete", is_done=True)
-
-            with trace("plan"):
-                self.printer.update_item("plan", "Drafting itinerary...")
-                plan_input = (
-                    f"Goal:\n{goal}\n\nTopics:\n{topics.model_dump_json()}\n\nSummaries:\n"
-                    f"{[s.summary for s in research_summaries]}"
+            self.printer.update_item("research", "Researching topics...")
+            for item in topics.topics:
+                input_text = (
+                    f"Search term: {item.query}\nReason for searching: {item.reason}"
                 )
-                plan_result = await Runner.run(planner_agent, plan_input)
-                plan = plan_result.final_output_as(TripOutput)
-                self.printer.update_item("plan", "Itinerary ready", is_done=True)
+                result = await Runner.run(research_agent, input_text)
+                summary = result.final_output_as(ResearchSummary)
+                research_summaries.append(summary)
+            self.printer.update_item("research", "Research complete", is_done=True)
+
+            self.printer.update_item("plan", "Drafting itinerary...")
+            plan_input = (
+                f"Goal:\n{goal}\n\nTopics:\n{topics.model_dump_json()}\n\nSummaries:\n"
+                f"{[s.summary for s in research_summaries]}"
+            )
+            plan_result = await Runner.run(planner_agent, plan_input)
+            plan = plan_result.final_output_as(TripOutput)
+            self.printer.update_item("plan", "Itinerary ready", is_done=True)
 
             return TripPipelineOutput(
                 topics=topics,

--- a/pocs/user_story_agent/deliverylead.py
+++ b/pocs/user_story_agent/deliverylead.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 from rich.console import Console
 from pydantic import BaseModel
 
-from agents import Agent, Runner, gen_trace_id, trace
+from agents import Agent, Runner
 from agents.extensions.visualization import draw_graph
 
 from .agent.functional_agent import FunctionalSpec, functional_agent
@@ -94,9 +94,8 @@ class DeliveryLeadManager:
             ]:
                 agent.model = model
 
-    async def run(self, feature: str) -> UserStoryPipelineOutput:
-        trace_id = gen_trace_id()
-        with trace("user_story_pipeline", trace_id=trace_id):
+    async def run(self, feature: str, trace_id: str | None = None) -> UserStoryPipelineOutput:
+        if trace_id:
             self.printer.update_item(
                 "trace_id",
                 f"View trace: https://platform.openai.com/traces/trace?trace_id={trace_id}",
@@ -105,103 +104,95 @@ class DeliveryLeadManager:
             )
             print(f"https://platform.openai.com/traces/trace?trace_id={trace_id}")
 
-            with trace("ux_spec"):
-                self.printer.update_item("ux", "Generating UX spec...")
-                ux_result = await Runner.run(ux_agent, feature)
-                ux = ux_result.final_output_as(UXSpec)
-                self.printer.update_item("ux", ux.spec, is_done=True)
+        self.printer.update_item("ux", "Generating UX spec...")
+        ux_result = await Runner.run(ux_agent, feature)
+        ux = ux_result.final_output_as(UXSpec)
+        self.printer.update_item("ux", ux.spec, is_done=True)
 
-            with trace("functional_spec"):
-                self.printer.update_item("functional", "Generating functional spec...")
-                func_input = f"Feature: {feature}\nUX spec:\n{ux.spec}"
-                func_result = await Runner.run(functional_agent, func_input)
-                functional = func_result.final_output_as(FunctionalSpec)
-                self.printer.update_item("functional", functional.spec, is_done=True)
+        self.printer.update_item("functional", "Generating functional spec...")
+        func_input = f"Feature: {feature}\nUX spec:\n{ux.spec}"
+        func_result = await Runner.run(functional_agent, func_input)
+        functional = func_result.final_output_as(FunctionalSpec)
+        self.printer.update_item("functional", functional.spec, is_done=True)
 
-            with trace("technical_spec"):
-                self.printer.update_item("technical", "Generating technical spec...")
-                tech_result = await Runner.run(technical_agent, functional.spec)
-                technical = tech_result.final_output_as(TechnicalSpec)
-                self.printer.update_item("technical", technical.spec, is_done=True)
+        self.printer.update_item("technical", "Generating technical spec...")
+        tech_result = await Runner.run(technical_agent, functional.spec)
+        technical = tech_result.final_output_as(TechnicalSpec)
+        self.printer.update_item("technical", technical.spec, is_done=True)
 
-            with trace("acceptance_criteria"):
-                self.printer.update_item("acceptance", "Writing acceptance criteria...")
-                acc_input = (
-                    f"Functional specification:\n{functional.spec}\n\n"
-                    f"Technical specification:\n{technical.spec}"
+        self.printer.update_item("acceptance", "Writing acceptance criteria...")
+        acc_input = (
+            f"Functional specification:\n{functional.spec}\n\n"
+            f"Technical specification:\n{technical.spec}"
+        )
+        acc_result = await Runner.run(acceptance_agent, acc_input)
+        acceptance = acc_result.final_output_as(AcceptanceCriteria)
+        self.printer.update_item("acceptance", acceptance.criteria, is_done=True)
+
+        self.printer.update_item("impact", "Assessing impact...")
+        impact_input = (
+            f"Functional specification:\n{functional.spec}\n\n"
+            f"Technical specification:\n{technical.spec}"
+        )
+        impact_agent = build_impact_agent(self.mcp_server, model=self.model)
+        impact_result = await Runner.run(impact_agent, impact_input)
+        impact = impact_result.final_output_as(ImpactSummary)
+        self.printer.update_item("impact", impact.summary, is_done=True)
+
+        self.printer.update_item("estimate", "Estimating story points...")
+        est_result = await Runner.run(estimate_agent, impact.summary)
+        estimate = est_result.final_output_as(StoryPointEstimate)
+        self.printer.update_item("estimate", str(estimate.points), is_done=True)
+
+        self.printer.update_item("story", "Writing user story...")
+        story_input = (
+            f"UX spec:\n{ux.spec}\n\n"
+            f"Functional spec:\n{functional.spec}\n\n"
+            f"Technical spec:\n{technical.spec}\n\n"
+            f"Acceptance criteria:\n{acceptance.criteria}\n\n"
+            f"Impact:\n{impact.summary}\n\n"
+            f"Story points: {estimate.points}"
+        )
+        story_result = await Runner.run(user_story_writer_agent, story_input)
+        story = story_result.final_output_as(UserStory)
+        self.printer.update_item("story", "Story drafted", is_done=True)
+
+        passes = False
+        iterations = 0
+        feedback = ""
+        while not passes and iterations < self.max_dor_iterations:
+            self.printer.update_item("dor", "Checking DoR...")
+            dor_input = story.story
+            if feedback:
+                dor_input += f"\n\nPrevious feedback:\n{feedback}"
+            dor_result = await Runner.run(dor_verifier_agent, dor_input)
+            dor = dor_result.final_output_as(DoRCheck)
+            passes = dor.passes
+            story.story = dor.story
+            feedback = dor.feedback
+            iterations += 1
+            if not passes and iterations < self.max_dor_iterations:
+                self.printer.update_item(
+                    "dor", f"Story failed DoR: {dor.feedback} Rewriting..."
                 )
-                acc_result = await Runner.run(acceptance_agent, acc_input)
-                acceptance = acc_result.final_output_as(AcceptanceCriteria)
-                self.printer.update_item("acceptance", acceptance.criteria, is_done=True)
-
-            with trace("impact_assessment"):
-                self.printer.update_item("impact", "Assessing impact...")
-                impact_input = (
-                    f"Functional specification:\n{functional.spec}\n\n"
-                    f"Technical specification:\n{technical.spec}"
+            elif not passes:
+                self.printer.update_item(
+                    "dor", "Max DoR iterations reached", is_done=True
                 )
-                impact_agent = build_impact_agent(self.mcp_server, model=self.model)
-                impact_result = await Runner.run(impact_agent, impact_input)
-                impact = impact_result.final_output_as(ImpactSummary)
-                self.printer.update_item("impact", impact.summary, is_done=True)
+            else:
+                self.printer.update_item("dor", "DoR passed", is_done=True)
 
-            with trace("storypoint_estimate"):
-                self.printer.update_item("estimate", "Estimating story points...")
-                est_result = await Runner.run(estimate_agent, impact.summary)
-                estimate = est_result.final_output_as(StoryPointEstimate)
-                self.printer.update_item("estimate", str(estimate.points), is_done=True)
-
-            with trace("user_story"):
-                self.printer.update_item("story", "Writing user story...")
-                story_input = (
-                    f"UX spec:\n{ux.spec}\n\n"
-                    f"Functional spec:\n{functional.spec}\n\n"
-                    f"Technical spec:\n{technical.spec}\n\n"
-                    f"Acceptance criteria:\n{acceptance.criteria}\n\n"
-                    f"Impact:\n{impact.summary}\n\n"
-                    f"Story points: {estimate.points}"
-                )
-                story_result = await Runner.run(user_story_writer_agent, story_input)
-                story = story_result.final_output_as(UserStory)
-                self.printer.update_item("story", "Story drafted", is_done=True)
-
-            passes = False
-            iterations = 0
-            feedback = ""
-            while not passes and iterations < self.max_dor_iterations:
-                with trace("dor_verification"):
-                    self.printer.update_item("dor", "Checking DoR...")
-                    dor_input = story.story
-                    if feedback:
-                        dor_input += f"\n\nPrevious feedback:\n{feedback}"
-                    dor_result = await Runner.run(dor_verifier_agent, dor_input)
-                    dor = dor_result.final_output_as(DoRCheck)
-                    passes = dor.passes
-                    story.story = dor.story
-                    feedback = dor.feedback
-                    iterations += 1
-                    if not passes and iterations < self.max_dor_iterations:
-                        self.printer.update_item(
-                            "dor", f"Story failed DoR: {dor.feedback} Rewriting..."
-                        )
-                    elif not passes:
-                        self.printer.update_item(
-                            "dor", "Max DoR iterations reached", is_done=True
-                        )
-                    else:
-                        self.printer.update_item("dor", "DoR passed", is_done=True)
-
-            self.printer.end()
-            return UserStoryPipelineOutput(
-                ux=ux,
-                functional=functional,
-                technical=technical,
-                acceptance=acceptance,
-                impact=impact,
-                estimate=estimate,
-                story=story,
-                dor=dor,
-            )
+        self.printer.end()
+        return UserStoryPipelineOutput(
+            ux=ux,
+            functional=functional,
+            technical=technical,
+            acceptance=acceptance,
+            impact=impact,
+            estimate=estimate,
+            story=story,
+            dor=dor,
+        )
 
 
 def visualize_workflow(filename: str | None = None):

--- a/pocs/user_story_agent/main.py
+++ b/pocs/user_story_agent/main.py
@@ -42,7 +42,7 @@ async def main() -> None:
         with trace("user_story_poc", trace_id=trace_id):
             mgr = DeliveryLeadManager(server, model=model)
             try:
-                result = await mgr.run(feature)
+                result = await mgr.run(feature, trace_id=trace_id)
             except InputGuardrailTripwireTriggered as exc:
                 info = exc.guardrail_result.output.output_info
                 print(f"\nInput rejected: {getattr(info, 'reason', '')}")


### PR DESCRIPTION
## Summary
- remove nested `trace()` spans and `Runner.run` `trace_id` usage
- print the trace link when a `trace_id` is provided

## Testing
- `python -m pocs.run_coach_agent.main --help`
- `python -m pocs.trip_planner_agent.main --help`
- `python -m pocs.user_story_agent.main --help`


------
https://chatgpt.com/codex/tasks/task_e_685e1b4f834c8326b8fe07df5eb8d8c8