### PR TITLE
Add Agents SDK features sections

### DIFF
--- a/pocs/run_coach_agent/README.md
+++ b/pocs/run_coach_agent/README.md
@@ -24,10 +24,23 @@ Each stage prints progress to the console so you can see the goal, collected dat
 - **Input:** a text description of your race goal and the Garmin CSV located in `resources/Activities.csv`
 - **Output:** the final training plan in the console and a markdown file under `outputs/` along with a workflow image
 
+
 ## Future enhancements
 - Support other fitness data sources such as Strava
 - Add injury risk detection and calendar export
 - Offer multiple plan strategies based on user experience
+
+## Agents SDK Features
+
+| SDK Feature | Benefit to PoC |
+|-------------|----------------|
+| `Agent` and `handoffs` | Coordinate goal, data collection, analysis and planning agents |
+| `Runner` | Executes each agent in sequence and gathers results |
+| `input_guardrail` | Rejects unrealistic race requests before execution |
+| `function_tool` | Loads Garmin CSV with a built-in function call |
+| `output_type` (Pydantic) | Provides typed results for each pipeline stage |
+| `trace` | Saves a trace of the run for debugging |
+| `visualization` | Generates a graph of the workflow |
 
 ## Running
 Install dependencies then execute:

--- a/pocs/trip_planner_agent/README.md
+++ b/pocs/trip_planner_agent/README.md
@@ -22,10 +22,24 @@ Progress is printed to the console so you can view topics, research summaries an
 - **Input:** a text description of your travel goals
 - **Output:** a markdown itinerary printed to the console and saved under `outputs/` along with a workflow image
 
+
 ## Future enhancements
 - Add budget estimates and restaurant recommendations
 - Integrate map links and calendar exports
 - Support alternate planning modes like backpacking or luxury travel
+
+## Agents SDK Features
+
+| SDK Feature | Benefit to PoC |
+|-------------|----------------|
+| `Agent` and `handoffs` | Chain topic, research and planner agents |
+| `Runner` | Executes each agent in sequence |
+| `WebSearchTool` | Gathers live results for each research topic |
+| `input_guardrail` & `output_guardrail` | Validates trip requests and itinerary quality |
+| `function_tool` | Provides helper functions such as getting the current date |
+| `output_type` (Pydantic) | Returns structured topics, research and plan |
+| `trace` | Records a trace for later review |
+| `visualization` | Generates a workflow diagram |
 
 ## Running
 Install dependencies then run:

--- a/pocs/user_story_agent/README.md
+++ b/pocs/user_story_agent/README.md
@@ -27,10 +27,23 @@ Progress for each stage is printed to the console so you can review the intermed
 - **Input:** a brief feature description and the technical architecture file in `resources/`
 - **Output:** the final user story printed to the console and saved under `outputs/` with a workflow image and all intermediate specs
 
+
 ## Future enhancements
 - Link directly to issue trackers for story creation
 - Add a persona repository for richer UX guidance
 - Provide optional code scaffolding based on the technical spec
+
+## Agents SDK Features
+
+| SDK Feature | Benefit to PoC |
+|-------------|----------------|
+| `Agent` and `handoffs` | Orchestrates UX, technical, acceptance and other specialist agents |
+| `Runner` | Executes each agent in sequence and collects results |
+| `MCPServer` | Supplies context files for impact assessment |
+| `input_guardrail` | Filters vague feature requests before processing |
+| `output_type` (Pydantic) | Structures the specs and final user story |
+| `trace` | Captures a trace of the workflow for debugging |
+| `visualization` | Produces a diagram of the agent flow |
 
 ## Running
 Install dependencies and run:


### PR DESCRIPTION
## Summary
- document Agents SDK features for each PoC

## Testing
- `bash pocs/run_coach_agent/test/run_test.sh` *(fails: KeyError: 'MODEL')*
- `bash pocs/trip_planner_agent/test/run_test.sh` *(fails: KeyError: 'MODEL')*
- `bash pocs/user_story_agent/test/run_test.sh` *(fails: KeyError: 'MODEL')*


------
https://chatgpt.com/codex/tasks/task_e_685e7617d6a48326a1d22b7caf147726