### PR TITLE
Improve agent outputs and trip planner prompt

### DIFF
--- a/pocs/run_coach_agent/main.py
+++ b/pocs/run_coach_agent/main.py
@@ -47,20 +47,24 @@ async def main() -> None:
     output_dir.mkdir(exist_ok=True)
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
     plan_file = output_dir / f"plan_{timestamp}.md"
+    resources = ["Activities.csv"]
     with open(plan_file, "w", encoding="utf-8") as f:
-        f.write("# Your Race Input\n")
+        f.write("## User:\n")
         f.write(goal + "\n\n")
 
-        f.write("# Race Goal\n")
+        f.write("## Resources:\n")
+        for r in resources:
+            f.write(f"- {r}\n")
+        f.write("\n")
+
+        f.write("## AI Agent:\n")
+        f.write("### Race Goal\n")
         f.write(str(result.goal) + "\n\n")
 
-        f.write("# Current Run Stats\n")
-        f.write(result.runs.csv + "\n\n")
-
-        f.write("# Run Analysis\n")
+        f.write("### Run Analysis\n")
         f.write(result.analysis.analysis + "\n\n")
 
-        f.write("# Training Plan\n")
+        f.write("### Training Plan\n")
         f.write(result.plan.plan)
 
     visualize_workflow(filename=str(output_dir / f"workflow_{timestamp}.png"))

--- a/pocs/trip_planner_agent/agent/guardrails.py
+++ b/pocs/trip_planner_agent/agent/guardrails.py
@@ -46,7 +46,8 @@ output_check_agent = Agent(
 class TripOutput(BaseModel):
     """Wrapper for planner output when validating."""
 
-    response: str
+    summary: str
+    itinerary: str
 
 
 @input_guardrail
@@ -69,7 +70,7 @@ async def trip_quality_guardrail(
     agent: Agent,
     output: TripOutput,
 ) -> GuardrailFunctionOutput:
-    result = await Runner.run(output_check_agent, output.response, context=ctx.context)
+    result = await Runner.run(output_check_agent, output.itinerary, context=ctx.context)
     decision = result.final_output_as(GuardrailDecision)
     return GuardrailFunctionOutput(
         output_info=decision,

--- a/pocs/trip_planner_agent/agent/planner_agent.py
+++ b/pocs/trip_planner_agent/agent/planner_agent.py
@@ -2,13 +2,14 @@
 from pathlib import Path
 from pydantic import BaseModel
 from agents import Agent
-from .guardrails import TripOutput, trip_quality_guardrail
+from .guardrails import trip_quality_guardrail
 
 
 class TripOutput(BaseModel):
     """Final travel plan response."""
 
-    response: str
+    summary: str
+    itinerary: str
 
 
 def _load_prompt() -> str:

--- a/pocs/trip_planner_agent/main.py
+++ b/pocs/trip_planner_agent/main.py
@@ -53,28 +53,42 @@ async def main() -> None:
             print(f"\nInvalid itinerary: {getattr(info, 'reason', '')}")
             return
 
-    print("\n--- Trip Itinerary ---\n")
-    print(result.plan.response)
+    print("\n--- Trip Plan ---\n")
+    print(result.plan.summary)
+    print()
+    print(result.plan.itinerary)
 
     output_dir = Path(__file__).resolve().parent / "outputs"
     output_dir.mkdir(exist_ok=True)
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
     plan_file = output_dir / f"trip_{timestamp}.md"
+    resources = []
     with open(plan_file, "w", encoding="utf-8") as f:
-        f.write("# Trip Goals\n")
+        f.write("## User:\n")
         f.write(goal + "\n\n")
 
-        f.write("# Research Topics\n")
+        f.write("## Resources:\n")
+        if resources:
+            for r in resources:
+                f.write(f"- {r}\n")
+        else:
+            f.write("None\n")
+        f.write("\n")
+
+        f.write("## AI Agent:\n")
+        f.write("### Trip Plan\n")
+        f.write(result.plan.summary + "\n\n")
+        f.write(result.plan.itinerary + "\n\n")
+
+        f.write("### More information\n")
+        f.write("#### Research Topics\n")
         for t in result.topics.topics:
             f.write(f"- {t.query} ({t.reason})\n")
         f.write("\n")
 
-        f.write("# Research Summaries\n")
+        f.write("#### Research Summaries\n")
         for r in result.research:
             f.write(r.summary + "\n\n")
-
-        f.write("# Trip Plan\n")
-        f.write(result.plan.response)
 
     visualize_workflow(filename=str(output_dir / f"workflow_{timestamp}.png"))
 

--- a/pocs/trip_planner_agent/prompts/plan_prompt.yaml
+++ b/pocs/trip_planner_agent/prompts/plan_prompt.yaml
@@ -1,4 +1,4 @@
 prompt: |
-  You are an expert travel planner. Using the user's travel goals, the list of
-  research topics and their summaries, write a short summary of key planning
-  considerations followed by a day-by-day itinerary. Return friendly markdown.
+  You are an expert travel planner. Using the user's travel goals and the research summaries,
+  produce markdown that first gives a **Summary** of key planning considerations and then a
+  **Daily Itinerary**. Ensure both sections are present.

--- a/pocs/user_story_agent/main.py
+++ b/pocs/user_story_agent/main.py
@@ -61,26 +61,34 @@ async def main() -> None:
             output_dir.mkdir(exist_ok=True)
             timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
             story_file = output_dir / f"story_{timestamp}.md"
+            resource_dir = context_dir
+            resource_files = [str(p.relative_to(resource_dir)) for p in resource_dir.rglob("*") if p.is_file()]
             with open(story_file, "w", encoding="utf-8") as f:
-                f.write("# Feature Input\n")
+                f.write("## User:\n")
                 f.write(feature + "\n\n")
 
-                f.write("# User Story\n")
+                f.write("## Resources:\n")
+                for r in resource_files:
+                    f.write(f"- {r}\n")
+                f.write("\n")
+
+                f.write("## AI Agent:\n")
+                f.write("### User Story\n")
                 f.write(result.story.story + "\n\n")
 
-                f.write("# UX Spec\n")
+                f.write("### UX Spec\n")
                 f.write(result.ux.spec + "\n\n")
 
-                f.write("# Functional Spec\n")
+                f.write("### Functional Spec\n")
                 f.write(result.functional.spec + "\n\n")
 
-                f.write("# Technical Spec\n")
+                f.write("### Technical Spec\n")
                 f.write(result.technical.spec + "\n\n")
 
-                f.write("# Acceptance Criteria\n")
+                f.write("### Acceptance Criteria\n")
                 f.write(result.acceptance.criteria + "\n\n")
 
-                f.write("# Impact Assessment\n")
+                f.write("### Impact Assessment\n")
                 f.write(result.impact.summary + "\n")
 
             visualize_workflow(filename=str(output_dir / f"workflow_{timestamp}.png"))


### PR DESCRIPTION
## Summary
- restructure Run Coach output file and drop CSV dump
- update Trip Planner plan output to include summary and itinerary
- reorder Trip Planner output sections and add resource section
- list user story resources in output and organize into User/Resources/AI Agent
- tweak trip planning prompt for clearer sections

## Testing
- `bash pocs/run_coach_agent/test/run_test.sh` *(fails: KeyError 'MODEL')*
- `bash pocs/trip_planner_agent/test/run_test.sh` *(fails: KeyError 'MODEL')*
- `bash pocs/user_story_agent/test/run_test.sh` *(fails: KeyError 'MODEL')*

------
https://chatgpt.com/codex/tasks/task_e_685e9fac33e08326963d3b8cfedc7ff5